### PR TITLE
Certificate.sha256Hash() method

### DIFF
--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -30,6 +30,9 @@ data class Certificate(
   val signatureAlgorithm: AlgorithmIdentifier,
   val signatureValue: BitString
 ) {
+  fun sha256Hash(): ByteString =
+    CertificateAdapters.subjectPublicKeyInfo.toDer(tbsCertificate.subjectPublicKeyInfo).sha256()
+
   val commonName: Any?
     get() {
       return tbsCertificate.subject

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -30,6 +30,9 @@ data class Certificate(
   val signatureAlgorithm: AlgorithmIdentifier,
   val signatureValue: BitString
 ) {
+  /**
+   * Certificate hash as used in HTTP Public Key Pinning.
+   */
   fun sha256Hash(): ByteString =
     CertificateAdapters.subjectPublicKeyInfo.toDer(tbsCertificate.subjectPublicKeyInfo).sha256()
 

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -36,6 +36,7 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.security.cert.X509Certificate
 
 internal class DerCertificatesTest {
   private val stateOrProvince = "1.3.6.1.4.1.311.60.2.1.2"
@@ -54,6 +55,9 @@ internal class DerCertificatesTest {
   private val certificatePolicies = "2.5.29.32"
   private val authorityKeyIdentifier = "2.5.29.35"
   private val extendedKeyUsage = "2.5.29.37"
+
+  fun X509Certificate.sha256Hash(): ByteString =
+    publicKey.encoded.toByteString().sha256()
 
   @Test
   fun `decode simple certificate`() {
@@ -81,6 +85,8 @@ internal class DerCertificatesTest {
 
     assertThat(okHttpCertificate.signatureValue.byteString)
         .isEqualTo(javaCertificate.signature.toByteString())
+
+    assertThat(okHttpCertificate.sha256Hash()).isEqualTo(javaCertificate.sha256Hash())
 
     val publicKeyBytes = ("3081890281810080a451e1b6b2da9f6f2afa8328959b9a4df58103457968c22fab7d81" +
         "b25a10bba2e5bd7d70278604a140a30e53ceb6986ded72db5260676c8ccdf3d5cae1425533a4aaa772bcf0a9" +

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -23,6 +23,7 @@ import app.cash.certifikit.ObjectIdentifiers.sha256WithRSAEncryption
 import app.cash.certifikit.ObjectIdentifiers.subjectAlternativeName
 import java.math.BigInteger
 import java.security.KeyFactory
+import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
 import java.text.SimpleDateFormat
@@ -36,7 +37,6 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.security.cert.X509Certificate
 
 internal class DerCertificatesTest {
   private val stateOrProvince = "1.3.6.1.4.1.311.60.2.1.2"


### PR DESCRIPTION
As used in https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning

> The HPKP policy specifies hashes of the subject public key info of one of the certificates in the website's authentic X.509 public key certificate chain (and at least one backup key) in pin-sha256 directives, and a period of time during which the user agent shall enforce public key pinning in max-age directive, optional includeSubDomains directive to include all subdomains (of the domain that sent the header) in pinning policy and optional report-uri directive with URL where to send pinning violation reports. At least one of the public keys of the certificates in the certificate chain needs to match a pinned public key in order for the chain to be considered valid by the user agent. 