### PR TITLE
Rename publicKeySha256Hash

### DIFF
--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
@@ -107,7 +107,7 @@ class Main : Callable<Int> {
   ) {
     when {
       output.isDirectory -> certificates.forEach {
-        outputCertificate(File(output, "${it.sha256Hash().hex()}.pem"), it)
+        outputCertificate(File(output, "${it.publicKeySha256Hash().hex()}.pem"), it)
       }
       else -> outputCertificate(output, certificates.first())
     }

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
@@ -107,7 +107,7 @@ class Main : Callable<Int> {
   ) {
     when {
       output.isDirectory -> certificates.forEach {
-        outputCertificate(File(output, "${it.publicKeySha256Hash().hex()}.pem"), it)
+        outputCertificate(File(output, "${it.publicKeySha256().hex()}.pem"), it)
       }
       else -> outputCertificate(output, certificates.first())
     }

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
@@ -25,7 +25,7 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import picocli.CommandLine.Help.Ansi
 
-fun X509Certificate.publicKeySha256Hash(): ByteString =
+fun X509Certificate.publicKeySha256(): ByteString =
   publicKey.encoded.toByteString()
       .sha256()
 
@@ -33,11 +33,11 @@ fun Certificate.prettyPrintCertificate(
   trustManager: X509TrustManager = Platform.get()
       .platformTrustManager()
 ): String {
-  val sha256 = this.publicKeySha256Hash()
+  val sha256 = this.publicKeySha256()
 
   return buildString {
     val trustedRoot = trustManager.acceptedIssuers.find {
-      it.publicKeySha256Hash() == sha256
+      it.publicKeySha256() == sha256
     } != null
     val trusted = if (trustedRoot) {
       Ansi.AUTO.string(" @|green (signed by locally-trusted root)|@")

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
@@ -25,7 +25,7 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import picocli.CommandLine.Help.Ansi
 
-fun X509Certificate.sha256Hash(): ByteString =
+fun X509Certificate.publicKeySha256Hash(): ByteString =
   publicKey.encoded.toByteString()
       .sha256()
 
@@ -33,11 +33,11 @@ fun Certificate.prettyPrintCertificate(
   trustManager: X509TrustManager = Platform.get()
       .platformTrustManager()
 ): String {
-  val sha256 = this.sha256Hash()
+  val sha256 = this.publicKeySha256Hash()
 
   return buildString {
     val trustedRoot = trustManager.acceptedIssuers.find {
-      it.sha256Hash() == sha256
+      it.publicKeySha256Hash() == sha256
     } != null
     val trusted = if (trustedRoot) {
       Ansi.AUTO.string(" @|green (signed by locally-trusted root)|@")

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -33,7 +33,7 @@ data class Certificate(
   /**
    * Certificate hash as used in HTTP Public Key Pinning.
    */
-  fun sha256Hash(): ByteString =
+  fun publicKeySha256Hash(): ByteString =
     CertificateAdapters.subjectPublicKeyInfo.toDer(tbsCertificate.subjectPublicKeyInfo).sha256()
 
   val commonName: String?

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -33,7 +33,7 @@ data class Certificate(
   /**
    * Certificate hash as used in HTTP Public Key Pinning.
    */
-  fun publicKeySha256Hash(): ByteString =
+  fun publicKeySha256(): ByteString =
     CertificateAdapters.subjectPublicKeyInfo.toDer(tbsCertificate.subjectPublicKeyInfo).sha256()
 
   val commonName: String?

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -86,7 +86,7 @@ internal class DerCertificatesTest {
     assertThat(okHttpCertificate.signatureValue.byteString)
         .isEqualTo(javaCertificate.signature.toByteString())
 
-    assertThat(okHttpCertificate.publicKeySha256Hash()).isEqualTo(javaCertificate.sha256Hash())
+    assertThat(okHttpCertificate.publicKeySha256()).isEqualTo(javaCertificate.sha256Hash())
 
     val publicKeyBytes = ("3081890281810080a451e1b6b2da9f6f2afa8328959b9a4df58103457968c22fab7d81" +
         "b25a10bba2e5bd7d70278604a140a30e53ceb6986ded72db5260676c8ccdf3d5cae1425533a4aaa772bcf0a9" +

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -86,7 +86,7 @@ internal class DerCertificatesTest {
     assertThat(okHttpCertificate.signatureValue.byteString)
         .isEqualTo(javaCertificate.signature.toByteString())
 
-    assertThat(okHttpCertificate.sha256Hash()).isEqualTo(javaCertificate.sha256Hash())
+    assertThat(okHttpCertificate.publicKeySha256Hash()).isEqualTo(javaCertificate.sha256Hash())
 
     val publicKeyBytes = ("3081890281810080a451e1b6b2da9f6f2afa8328959b9a4df58103457968c22fab7d81" +
         "b25a10bba2e5bd7d70278604a140a30e53ceb6986ded72db5260676c8ccdf3d5cae1425533a4aaa772bcf0a9" +


### PR DESCRIPTION
Rename since this particular hash is not for the entire certificate and is specifically an item from HPKP