### PR TITLE
ktlint upgrade and apply

### DIFF
--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/Main.kt
@@ -22,12 +22,6 @@ import app.cash.certifikit.cli.Main.Companion.NAME
 import app.cash.certifikit.cli.Main.VersionProvider
 import app.cash.certifikit.cli.errors.CertificationException
 import app.cash.certifikit.cli.errors.UsageException
-import java.io.File
-import java.io.FileNotFoundException
-import java.io.IOException
-import java.security.cert.X509Certificate
-import java.util.concurrent.Callable
-import kotlin.system.exitProcess
 import okhttp3.internal.platform.Platform
 import okio.ByteString.Companion.toByteString
 import picocli.CommandLine
@@ -36,10 +30,18 @@ import picocli.CommandLine.Help.Ansi
 import picocli.CommandLine.IVersionProvider
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.security.cert.X509Certificate
+import java.util.concurrent.Callable
+import kotlin.system.exitProcess
 
 @Command(
-    name = NAME, description = ["An ergonomic CLI for understanding certificates."],
-    mixinStandardHelpOptions = true, versionProvider = VersionProvider::class
+  name = NAME,
+  description = ["An ergonomic CLI for understanding certificates."],
+  mixinStandardHelpOptions = true,
+  versionProvider = VersionProvider::class
 )
 class Main : Callable<Int> {
   @Option(names = ["--host"], description = ["From HTTPS Handshake"])

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certificateOutput.kt
@@ -18,16 +18,16 @@ package app.cash.certifikit.cli
 import app.cash.certifikit.Certificate
 import app.cash.certifikit.ObjectIdentifiers
 import app.cash.certifikit.decodeKeyUsage
-import java.security.cert.X509Certificate
-import java.time.Instant.ofEpochMilli
-import javax.net.ssl.X509TrustManager
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import picocli.CommandLine.Help.Ansi
+import java.security.cert.X509Certificate
+import java.time.Instant.ofEpochMilli
+import javax.net.ssl.X509TrustManager
 
 fun X509Certificate.publicKeySha256(): ByteString =
   publicKey.encoded.toByteString()
-      .sha256()
+    .sha256()
 
 fun Certificate.prettyPrintCertificate(
   trustManager: X509TrustManager
@@ -67,11 +67,11 @@ fun Certificate.prettyPrintCertificate(
       else -> " (${periodLeft.days})"
     }
     append(
-        "Valid: \t${
-          ofEpochMilli(tbsCertificate.validity.notBefore)
-        }..${
-          ofEpochMilli(tbsCertificate.validity.notAfter)
-        }$periodLeftString"
+      "Valid: \t${
+      ofEpochMilli(tbsCertificate.validity.notBefore)
+      }..${
+      ofEpochMilli(tbsCertificate.validity.notAfter)
+      }$periodLeftString"
     )
 
     basicConstraints?.apply {
@@ -85,13 +85,13 @@ private fun Certificate.subjectAlternativeNameValue() =
   tbsCertificate.extensions.firstOrNull {
     it.id == ObjectIdentifiers.subjectAlternativeName
   }
-      ?.let {
-        @Suppress("UNCHECKED_CAST")
-        it.value as List<Pair<Any, Any>>
-      }
-      ?.map {
-        it.second.toString()
-      }
+    ?.let {
+      @Suppress("UNCHECKED_CAST")
+      it.value as List<Pair<Any, Any>>
+    }
+    ?.map {
+      it.second.toString()
+    }
 
 /**
  * Returns the certificate encoded in [PEM format][rfc_7468].

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
@@ -21,12 +21,15 @@ import app.cash.certifikit.cli.errors.UsageException
 import okio.ByteString.Companion.decodeBase64
 
 internal fun String.parsePemCertificate(fileName: String? = null): Certificate {
-    val regex = """-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----""".toRegex(RegexOption.DOT_MATCHES_ALL)
-    val matchResult = regex.find(this) ?: throw UsageException("Invalid format" +
-            if (fileName != null) ": $fileName" else "")
-    val (pemBody) = matchResult.destructured
+  val regex =
+    """-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----""".toRegex(RegexOption.DOT_MATCHES_ALL)
+  val matchResult = regex.find(this) ?: throw UsageException(
+    "Invalid format" +
+      if (fileName != null) ": $fileName" else ""
+  )
+  val (pemBody) = matchResult.destructured
 
-    val data = pemBody.decodeBase64()!!
+  val data = pemBody.decodeBase64()!!
 
-    return CertificateAdapters.certificate.fromDer(data)
+  return CertificateAdapters.certificate.fromDer(data)
 }

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/errors/errorCategorisation.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/errors/errorCategorisation.kt
@@ -31,11 +31,13 @@ fun Main.classify(
   return when {
     // java.security.cert.CertificateExpiredException: NotAfter: Mon Apr 13 00:59:59 BST 2015
     e.findMatchingCause { it is CertificateExpiredException } != null -> CertificationException(
-        "Certificate for $host is expired", e
+      "Certificate for $host is expired",
+      e
     )
     // javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
     e.findMatchingCause { it.javaClass.simpleName == "SunCertPathBuilderException" } != null -> CertificationException(
-        "Certificate for $host is untrusted", e
+      "Certificate for $host is untrusted",
+      e
     )
     // SSLPeerUnverifiedException: Hostname wrong.host.badssl.com not verified:
     e is javax.net.ssl.SSLPeerUnverifiedException -> CertificationException(e.message!!, e)
@@ -43,14 +45,16 @@ fun Main.classify(
     e is java.net.UnknownHostException -> CertificationException("DNS Lookup Failed: $host", e)
     // java.net.SocketTimeoutException: Connect timed out
     e is java.net.SocketTimeoutException -> CertificationException(
-        "No response from server: $host", e
+      "No response from server: $host",
+      e
     )
     // javax.net.ssl.SSLException: java.lang.RuntimeException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
     e.findMatchingCause { it is InvalidAlgorithmParameterException } != null ->
       CertificationException("No trusted CA certificates in keystore", e)
     // javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
     e is SSLHandshakeException -> CertificationException(
-        "SSL Handshake Failure: ${e.message} ${if (insecure) "" else ", try with --insecure"}", e
+      "SSL Handshake Failure: ${e.message} ${if (insecure) "" else ", try with --insecure"}",
+      e
     )
     // java.net.ConnectException: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:443
     e is ConnectException -> CertificationException(e.message ?: "Unable to connect to host", e)

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/http.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/http.kt
@@ -17,14 +17,6 @@ package app.cash.certifikit.cli
 
 import app.cash.certifikit.Certifikit
 import app.cash.certifikit.cli.errors.classify
-import java.io.IOException
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
-import java.security.cert.X509Certificate
-import java.util.concurrent.TimeUnit.SECONDS
-import javax.net.ssl.HostnameVerifier
-import javax.net.ssl.X509TrustManager
 import okhttp3.Call
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
@@ -43,6 +35,14 @@ import okhttp3.TlsVersion.TLS_1_2
 import okhttp3.TlsVersion.TLS_1_3
 import okhttp3.tls.HandshakeCertificates
 import picocli.CommandLine.Help.Ansi
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit.SECONDS
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.X509TrustManager
 
 enum class Strength(val color: String) {
   Good("green"), Weak("yellow"), Bad("red")
@@ -71,40 +71,40 @@ val userAgent = "Certifikit/" + Certifikit.VERSION + " OkHttp/" + OkHttp.VERSION
 
 fun Main.fromHttps(host: String): List<X509Certificate> {
   val client = OkHttpClient.Builder()
-      .connectTimeout(2, SECONDS)
-      .followRedirects(followRedirects)
-      .eventListener(VerboseEventListener(verbose))
-      .connectionSpecs(listOf(MODERN_TLS)) // The specs may be overriden later.
-      .apply {
-        if (insecure) {
-          hostnameVerifier(HostnameVerifier { _, _ -> true })
+    .connectTimeout(2, SECONDS)
+    .followRedirects(followRedirects)
+    .eventListener(VerboseEventListener(verbose))
+    .connectionSpecs(listOf(MODERN_TLS)) // The specs may be overriden later.
+    .apply {
+      if (insecure) {
+        hostnameVerifier(HostnameVerifier { _, _ -> true })
 
-          val handshakeCertificates = HandshakeCertificates.Builder()
-              .addTrustedCertificates(trustManager)
-              .addInsecureHost(host)
-              .build()
-          sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
+        val handshakeCertificates = HandshakeCertificates.Builder()
+          .addTrustedCertificates(trustManager)
+          .addInsecureHost(host)
+          .build()
+        sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
 
-          val spec = ConnectionSpec.Builder(COMPATIBLE_TLS)
-              .allEnabledCipherSuites()
-              .allEnabledTlsVersions()
-              .build()
+        val spec = ConnectionSpec.Builder(COMPATIBLE_TLS)
+          .allEnabledCipherSuites()
+          .allEnabledTlsVersions()
+          .build()
 
-          connectionSpecs(listOf(spec))
-        } else if (keyStoreFile != null) {
-          val handshakeCertificates = HandshakeCertificates.Builder()
-              .addTrustedCertificates(trustManager)
-              .build()
-          sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
-        }
+        connectionSpecs(listOf(spec))
+      } else if (keyStoreFile != null) {
+        val handshakeCertificates = HandshakeCertificates.Builder()
+          .addTrustedCertificates(trustManager)
+          .build()
+        sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
       }
-      .build()
+    }
+    .build()
 
   val call = client.newCall(
-      Request.Builder()
-          .url("https://$host/")
-          .header("User-Agent", userAgent)
-          .build()
+    Request.Builder()
+      .url("https://$host/")
+      .header("User-Agent", userAgent)
+      .build()
   )
 
   val response = try {
@@ -116,7 +116,7 @@ fun Main.fromHttps(host: String): List<X509Certificate> {
   return response.use {
     it.handshake!!.peerCertificates
   }
-      .map { it as X509Certificate }
+    .map { it as X509Certificate }
 }
 
 private fun HandshakeCertificates.Builder.addTrustedCertificates(

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/keystore.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/keystore.kt
@@ -22,18 +22,19 @@ import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
 fun File.trustManager(): X509TrustManager {
-    val factory = TrustManagerFactory.getInstance(
-            TrustManagerFactory.getDefaultAlgorithm())
+  val factory = TrustManagerFactory.getInstance(
+    TrustManagerFactory.getDefaultAlgorithm()
+  )
 
-    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
-    this.inputStream().use {
-        keyStore.load(it, null)
-    }
-    factory.init(keyStore)
+  val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+  this.inputStream().use {
+    keyStore.load(it, null)
+  }
+  factory.init(keyStore)
 
-    val trustManagers = factory.trustManagers!!
-    check(trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
-        "Unexpected default trust managers: ${trustManagers.contentToString()}"
-    }
-    return trustManagers[0] as X509TrustManager
+  val trustManagers = factory.trustManagers!!
+  check(trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
+    "Unexpected default trust managers: ${trustManagers.contentToString()}"
+  }
+  return trustManagers[0] as X509TrustManager
 }

--- a/certifikit-cli/src/test/kotlin/app/cash/certifikit/cli/CertificateOutputTest.kt
+++ b/certifikit-cli/src/test/kotlin/app/cash/certifikit/cli/CertificateOutputTest.kt
@@ -22,7 +22,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class CertificateOutputTest {
-  val certificateBase64 = """
+  val certificateBase64 =
+    """
         |MIIHHTCCBgWgAwIBAgIRAL5oALmpH7l6AAAAAFTRMh0wDQYJKoZIhvcNAQELBQAw
         |gboxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1FbnRydXN0LCBJbmMuMSgwJgYDVQQL
         |Ex9TZWUgd3d3LmVudHJ1c3QubmV0L2xlZ2FsLXRlcm1zMTkwNwYDVQQLEzAoYykg
@@ -71,7 +72,8 @@ class CertificateOutputTest {
 
     val output = okHttpCertificate.prettyPrintCertificate(Platform.get().platformTrustManager())
 
-    assertThat(output).matches("""
+    assertThat(output).matches(
+      """
       |CN: 	cash\.app
       |Pin:	sha256/43a60e5aecabd897cbbcf833150740e18ff0c3d90bde132354dc85a4869b3269
       |SAN: 	cash\.app, www\.cash\.app
@@ -79,6 +81,7 @@ class CertificateOutputTest {
       |Ext Key Usage: serverAuth, clientAuth
       |Valid: 	2020-04-13T13:25:49Z\.\.2021-04-12T13:55:49Z (.*)
       |CA: false
-    """.trimMargin())
+    """.trimMargin()
+    )
   }
 }

--- a/certifikit-cli/src/test/kotlin/app/cash/certifikit/cli/TestCerts.kt
+++ b/certifikit-cli/src/test/kotlin/app/cash/certifikit/cli/TestCerts.kt
@@ -15,14 +15,14 @@
  */
 package app.cash.certifikit.cli
 
-import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.io.File
 
 class TestCerts {
   @Test
   fun parseCert() {
-      val cert = File("src/test/resources/cert.pem").readText().parsePemCertificate()
-      assertThat(cert.signatureAlgorithm.algorithm).isEqualTo("1.2.840.113549.1.1.11")
+    val cert = File("src/test/resources/cert.pem").readText().parsePemCertificate()
+    assertThat(cert.signatureAlgorithm.algorithm).isEqualTo("1.2.840.113549.1.1.11")
   }
 }

--- a/certifikit/src/main/kotlin/app/cash/certifikit/Adapters.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/Adapters.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.certifikit
 
+import okio.ByteString
 import java.math.BigInteger
 import java.net.ProtocolException
 import java.text.ParseException
@@ -22,91 +23,90 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
 import kotlin.reflect.KClass
-import okio.ByteString
 
 /**
  * Built-in adapters for reading standard ASN.1 types.
  */
 internal object Adapters {
   val BOOLEAN = BasicDerAdapter(
-      name = "BOOLEAN",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 1L,
-      codec = object : BasicDerAdapter.Codec<Boolean> {
-        override fun decode(reader: DerReader) = reader.readBoolean()
-        override fun encode(writer: DerWriter, value: Boolean) = writer.writeBoolean(value)
-      }
+    name = "BOOLEAN",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 1L,
+    codec = object : BasicDerAdapter.Codec<Boolean> {
+      override fun decode(reader: DerReader) = reader.readBoolean()
+      override fun encode(writer: DerWriter, value: Boolean) = writer.writeBoolean(value)
+    }
   )
 
   val INTEGER_AS_LONG = BasicDerAdapter(
-      name = "INTEGER",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 2L,
-      codec = object : BasicDerAdapter.Codec<Long> {
-        override fun decode(reader: DerReader) = reader.readLong()
-        override fun encode(writer: DerWriter, value: Long) = writer.writeLong(value)
-      }
+    name = "INTEGER",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 2L,
+    codec = object : BasicDerAdapter.Codec<Long> {
+      override fun decode(reader: DerReader) = reader.readLong()
+      override fun encode(writer: DerWriter, value: Long) = writer.writeLong(value)
+    }
   )
 
   val INTEGER_AS_BIG_INTEGER = BasicDerAdapter(
-      name = "INTEGER",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 2L,
-      codec = object : BasicDerAdapter.Codec<BigInteger> {
-        override fun decode(reader: DerReader) = reader.readBigInteger()
-        override fun encode(writer: DerWriter, value: BigInteger) = writer.writeBigInteger(value)
-      }
+    name = "INTEGER",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 2L,
+    codec = object : BasicDerAdapter.Codec<BigInteger> {
+      override fun decode(reader: DerReader) = reader.readBigInteger()
+      override fun encode(writer: DerWriter, value: BigInteger) = writer.writeBigInteger(value)
+    }
   )
 
   val BIT_STRING = BasicDerAdapter(
-      name = "BIT STRING",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 3L,
-      codec = object : BasicDerAdapter.Codec<BitString> {
-        override fun decode(reader: DerReader) = reader.readBitString()
-        override fun encode(writer: DerWriter, value: BitString) = writer.writeBitString(value)
-      }
+    name = "BIT STRING",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 3L,
+    codec = object : BasicDerAdapter.Codec<BitString> {
+      override fun decode(reader: DerReader) = reader.readBitString()
+      override fun encode(writer: DerWriter, value: BitString) = writer.writeBitString(value)
+    }
   )
 
   val OCTET_STRING = BasicDerAdapter(
-      name = "OCTET STRING",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 4L,
-      codec = object : BasicDerAdapter.Codec<ByteString> {
-        override fun decode(reader: DerReader) = reader.readOctetString()
-        override fun encode(writer: DerWriter, value: ByteString) = writer.writeOctetString(value)
-      }
+    name = "OCTET STRING",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 4L,
+    codec = object : BasicDerAdapter.Codec<ByteString> {
+      override fun decode(reader: DerReader) = reader.readOctetString()
+      override fun encode(writer: DerWriter, value: ByteString) = writer.writeOctetString(value)
+    }
   )
 
   val NULL = BasicDerAdapter(
-      name = "NULL",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 5L,
-      codec = object : BasicDerAdapter.Codec<Unit?> {
-        override fun decode(reader: DerReader) = null
-        override fun encode(writer: DerWriter, value: Unit?) {
-        }
+    name = "NULL",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 5L,
+    codec = object : BasicDerAdapter.Codec<Unit?> {
+      override fun decode(reader: DerReader) = null
+      override fun encode(writer: DerWriter, value: Unit?) {
       }
+    }
   )
 
   val OBJECT_IDENTIFIER = BasicDerAdapter(
-      name = "OBJECT IDENTIFIER",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 6L,
-      codec = object : BasicDerAdapter.Codec<String> {
-        override fun decode(reader: DerReader) = reader.readObjectIdentifier()
-        override fun encode(writer: DerWriter, value: String) = writer.writeObjectIdentifier(value)
-      }
+    name = "OBJECT IDENTIFIER",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 6L,
+    codec = object : BasicDerAdapter.Codec<String> {
+      override fun decode(reader: DerReader) = reader.readObjectIdentifier()
+      override fun encode(writer: DerWriter, value: String) = writer.writeObjectIdentifier(value)
+    }
   )
 
   val UTF8_STRING = BasicDerAdapter(
-      name = "UTF8",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 12L,
-      codec = object : BasicDerAdapter.Codec<String> {
-        override fun decode(reader: DerReader) = reader.readUtf8String()
-        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-      }
+    name = "UTF8",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 12L,
+    codec = object : BasicDerAdapter.Codec<String> {
+      override fun decode(reader: DerReader) = reader.readUtf8String()
+      override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+    }
   )
 
   /**
@@ -118,13 +118,13 @@ internal object Adapters {
    */
   // TODO(jwilson): constrain to printable string characters.
   val PRINTABLE_STRING = BasicDerAdapter(
-      name = "PRINTABLE STRING",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 19L,
-      codec = object : BasicDerAdapter.Codec<String> {
-        override fun decode(reader: DerReader) = reader.readUtf8String()
-        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-      }
+    name = "PRINTABLE STRING",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 19L,
+    codec = object : BasicDerAdapter.Codec<String> {
+      override fun decode(reader: DerReader) = reader.readUtf8String()
+      override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+    }
   )
 
   /**
@@ -133,13 +133,13 @@ internal object Adapters {
    */
   // TODO(jwilson): constrain to IA5 characters.
   val IA5_STRING = BasicDerAdapter(
-      name = "IA5 STRING",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 22L,
-      codec = object : BasicDerAdapter.Codec<String> {
-        override fun decode(reader: DerReader) = reader.readUtf8String()
-        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-      }
+    name = "IA5 STRING",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 22L,
+    codec = object : BasicDerAdapter.Codec<String> {
+      override fun decode(reader: DerReader) = reader.readUtf8String()
+      override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+    }
   )
 
   /**
@@ -147,19 +147,19 @@ internal object Adapters {
    * cutoff of the 2-digit year is 1950-01-01T00:00:00Z.
    */
   val UTC_TIME = BasicDerAdapter(
-      name = "UTC TIME",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 23L,
-      codec = object : BasicDerAdapter.Codec<Long> {
-        override fun decode(reader: DerReader): Long {
-          val string = reader.readUtf8String()
-          return parseUtcTime(string)
-        }
-        override fun encode(writer: DerWriter, value: Long) {
-          val string = formatUtcTime(value)
-          return writer.writeUtf8(string)
-        }
+    name = "UTC TIME",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 23L,
+    codec = object : BasicDerAdapter.Codec<Long> {
+      override fun decode(reader: DerReader): Long {
+        val string = reader.readUtf8String()
+        return parseUtcTime(string)
       }
+      override fun encode(writer: DerWriter, value: Long) {
+        val string = formatUtcTime(value)
+        return writer.writeUtf8(string)
+      }
+    }
   )
 
   internal fun parseUtcTime(string: String): Long {
@@ -192,19 +192,19 @@ internal object Adapters {
    * is the same as [UTC_TIME] with the exception of the 4-digit year.
    */
   val GENERALIZED_TIME = BasicDerAdapter(
-      name = "GENERALIZED TIME",
-      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 24L,
-      codec = object : BasicDerAdapter.Codec<Long> {
-        override fun decode(reader: DerReader): Long {
-          val string = reader.readUtf8String()
-          return parseGeneralizedTime(string)
-        }
-        override fun encode(writer: DerWriter, value: Long) {
-          val string = formatGeneralizedTime(value)
-          return writer.writeUtf8(string)
-        }
+    name = "GENERALIZED TIME",
+    tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+    tag = 24L,
+    codec = object : BasicDerAdapter.Codec<Long> {
+      override fun decode(reader: DerReader): Long {
+        val string = reader.readUtf8String()
+        return parseGeneralizedTime(string)
       }
+      override fun encode(writer: DerWriter, value: Long) {
+        val string = formatGeneralizedTime(value)
+        return writer.writeUtf8(string)
+      }
+    }
   )
 
   /** Decodes any value without interpretation as [AnyValue]. */
@@ -215,11 +215,11 @@ internal object Adapters {
       reader.read("ANY") { header ->
         val bytes = reader.readUnknown()
         return AnyValue(
-            tagClass = header.tagClass,
-            tag = header.tag,
-            constructed = header.constructed,
-            length = header.length,
-            bytes = bytes
+          tagClass = header.tagClass,
+          tag = header.tag,
+          constructed = header.constructed,
+          length = header.length,
+          bytes = bytes
         )
       }
     }
@@ -301,10 +301,10 @@ internal object Adapters {
     }
 
     return BasicDerAdapter(
-        name = name,
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 16L,
-        codec = codec
+      name = name,
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 16L,
+      codec = codec
     )
   }
 
@@ -315,11 +315,12 @@ internal object Adapters {
 
       override fun fromDer(reader: DerReader): Pair<DerAdapter<*>, Any?> {
         val peekedHeader = reader.peekHeader()
-            ?: throw ProtocolException("expected a value at $reader")
+          ?: throw ProtocolException("expected a value at $reader")
 
         val choice = choices.firstOrNull { it.matches(peekedHeader) }
-            ?: throw ProtocolException(
-                "expected a matching choice but was $peekedHeader at $reader")
+          ?: throw ProtocolException(
+            "expected a matching choice but was $peekedHeader at $reader"
+          )
 
         return choice to choice.fromDer(reader)
       }
@@ -374,18 +375,18 @@ internal object Adapters {
    * have very different ASN.1 interpretations.
    */
   private val defaultAnyChoices = listOf(
-      Boolean::class to BOOLEAN,
-      BigInteger::class to INTEGER_AS_BIG_INTEGER,
-      BitString::class to BIT_STRING,
-      ByteString::class to OCTET_STRING,
-      Unit::class to NULL,
-      Nothing::class to OBJECT_IDENTIFIER,
-      Nothing::class to UTF8_STRING,
-      String::class to PRINTABLE_STRING,
-      Nothing::class to IA5_STRING,
-      Nothing::class to UTC_TIME,
-      Long::class to GENERALIZED_TIME,
-      AnyValue::class to ANY_VALUE
+    Boolean::class to BOOLEAN,
+    BigInteger::class to INTEGER_AS_BIG_INTEGER,
+    BitString::class to BIT_STRING,
+    ByteString::class to OCTET_STRING,
+    Unit::class to NULL,
+    Nothing::class to OBJECT_IDENTIFIER,
+    Nothing::class to UTF8_STRING,
+    String::class to PRINTABLE_STRING,
+    Nothing::class to IA5_STRING,
+    Nothing::class to UTC_TIME,
+    Long::class to GENERALIZED_TIME,
+    AnyValue::class to ANY_VALUE
   )
 
   fun any(
@@ -417,7 +418,7 @@ internal object Adapters {
         if (isOptional && !reader.hasNext()) return optionalValue
 
         val peekedHeader = reader.peekHeader()
-            ?: throw ProtocolException("expected a value at $reader")
+          ?: throw ProtocolException("expected a value at $reader")
         for ((_, adapter) in choices) {
           if (adapter.matches(peekedHeader)) {
             return adapter.fromDer(reader)

--- a/certifikit/src/main/kotlin/app/cash/certifikit/BitString.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/BitString.kt
@@ -15,8 +15,8 @@
  */
 package app.cash.certifikit
 
-import java.math.BigInteger
 import okio.ByteString
+import java.math.BigInteger
 
 /**
  * Like a [ByteString], but whose bits are not necessarily a strict multiple of 8.
@@ -36,17 +36,17 @@ data class BitString(
   }
 
   val bitSet: List<Int>
-  get() {
-    if (byteString.size == 0)
-      return listOf()
+    get() {
+      if (byteString.size == 0)
+        return listOf()
 
-    // Bits are encoded from the front, with lowest value bits possibly ignored.
-    val maxResultBit = byteString.size * 8 - 1 - this.unusedBitsCount
-    val bitField = BigInteger(byteString.toByteArray())
+      // Bits are encoded from the front, with lowest value bits possibly ignored.
+      val maxResultBit = byteString.size * 8 - 1 - this.unusedBitsCount
+      val bitField = BigInteger(byteString.toByteArray())
 
-    return (0..maxResultBit).mapNotNull {
-      val offset = (maxResultBit - it) + unusedBitsCount
-      if (bitField.testBit(offset)) it else null
+      return (0..maxResultBit).mapNotNull {
+        val offset = (maxResultBit - it) + unusedBitsCount
+        if (bitField.testBit(offset)) it else null
+      }
     }
-  }
 }

--- a/certifikit/src/main/kotlin/app/cash/certifikit/CertificateAdapters.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/CertificateAdapters.kt
@@ -18,9 +18,9 @@ package app.cash.certifikit
 import app.cash.certifikit.Adapters.BIT_STRING
 import app.cash.certifikit.Adapters.OBJECT_IDENTIFIER
 import app.cash.certifikit.attestation.AttestationAdapters
+import okio.ByteString
 import java.math.BigInteger
 import java.net.ProtocolException
-import okio.ByteString
 
 /**
  * ASN.1 adapters adapted from the specifications in [RFC 5280][rfc_5280].
@@ -50,15 +50,15 @@ object CertificateAdapters {
 
     override fun fromDer(reader: DerReader): Long {
       val peekHeader = reader.peekHeader()
-          ?: throw ProtocolException("expected time but was exhausted at $reader")
+        ?: throw ProtocolException("expected time but was exhausted at $reader")
 
       return when {
         peekHeader.tagClass == Adapters.UTC_TIME.tagClass &&
-            peekHeader.tag == Adapters.UTC_TIME.tag -> {
+          peekHeader.tag == Adapters.UTC_TIME.tag -> {
           Adapters.UTC_TIME.fromDer(reader)
         }
         peekHeader.tagClass == Adapters.GENERALIZED_TIME.tagClass &&
-            peekHeader.tag == Adapters.GENERALIZED_TIME.tag -> {
+          peekHeader.tag == Adapters.GENERALIZED_TIME.tag -> {
           Adapters.GENERALIZED_TIME.fromDer(reader)
         }
         else -> throw ProtocolException("expected time but was $peekHeader at $reader")
@@ -84,21 +84,21 @@ object CertificateAdapters {
    * ```
    */
   private val validity: BasicDerAdapter<Validity> = Adapters.sequence(
-      "Validity",
-      time,
-      time,
-      decompose = {
-        listOf(
-            it.notBefore,
-            it.notAfter
-        )
-      },
-      construct = {
-        Validity(
-            notBefore = it[0] as Long,
-            notAfter = it[1] as Long
-        )
-      }
+    "Validity",
+    time,
+    time,
+    decompose = {
+      listOf(
+        it.notBefore,
+        it.notAfter
+      )
+    },
+    construct = {
+      Validity(
+        notBefore = it[0] as Long,
+        notAfter = it[1] as Long
+      )
+    }
   )
 
   /** The type of the parameters depends on the algorithm that precedes it. */
@@ -123,21 +123,21 @@ object CertificateAdapters {
    * ```
    */
   internal val algorithmIdentifier: BasicDerAdapter<AlgorithmIdentifier> = Adapters.sequence(
-      "AlgorithmIdentifier",
-      Adapters.OBJECT_IDENTIFIER.asTypeHint(),
-      algorithmParameters,
-      decompose = {
-        listOf(
-            it.algorithm,
-            it.parameters
-        )
-      },
-      construct = {
-        AlgorithmIdentifier(
-            algorithm = it[0] as String,
-            parameters = it[1]
-        )
-      }
+    "AlgorithmIdentifier",
+    Adapters.OBJECT_IDENTIFIER.asTypeHint(),
+    algorithmParameters,
+    decompose = {
+      listOf(
+        it.algorithm,
+        it.parameters
+      )
+    },
+    construct = {
+      AlgorithmIdentifier(
+        algorithm = it[0] as String,
+        parameters = it[1]
+      )
+    }
   )
 
   /**
@@ -149,21 +149,21 @@ object CertificateAdapters {
    * ```
    */
   private val basicConstraints: BasicDerAdapter<BasicConstraints> = Adapters.sequence(
-      "BasicConstraints",
-      Adapters.BOOLEAN.optional(defaultValue = false),
-      Adapters.INTEGER_AS_LONG.optional(),
-      decompose = {
-        listOf(
-            it.ca,
-            it.maxIntermediateCas
-        )
-      },
-      construct = {
-        BasicConstraints(
-            ca = it[0] as Boolean,
-            maxIntermediateCas = it[1] as Long?
-        )
-      }
+    "BasicConstraints",
+    Adapters.BOOLEAN.optional(defaultValue = false),
+    Adapters.INTEGER_AS_LONG.optional(),
+    decompose = {
+      listOf(
+        it.ca,
+        it.maxIntermediateCas
+      )
+    },
+    construct = {
+      BasicConstraints(
+        ca = it[0] as Boolean,
+        maxIntermediateCas = it[1] as Long?
+      )
+    }
   )
 
   /**
@@ -188,9 +188,9 @@ object CertificateAdapters {
   internal val generalNameDnsName = Adapters.IA5_STRING.withTag(tag = 2L)
   internal val generalNameIpAddress = Adapters.OCTET_STRING.withTag(tag = 7L)
   internal val generalName: DerAdapter<Pair<DerAdapter<*>, Any?>> = Adapters.choice(
-      generalNameDnsName,
-      generalNameIpAddress,
-      Adapters.ANY_VALUE
+    generalNameDnsName,
+    generalNameIpAddress,
+    Adapters.ANY_VALUE
   )
 
   /**
@@ -217,9 +217,9 @@ object CertificateAdapters {
       else -> null
     }
   }.withExplicitBox(
-      tagClass = Adapters.OCTET_STRING.tagClass,
-      tag = Adapters.OCTET_STRING.tag,
-      forceConstructed = false
+    tagClass = Adapters.OCTET_STRING.tagClass,
+    tag = Adapters.OCTET_STRING.tag,
+    forceConstructed = false
   )
 
   /**
@@ -235,24 +235,24 @@ object CertificateAdapters {
    * ```
    */
   internal val extension: BasicDerAdapter<Extension> = Adapters.sequence(
-      "Extension",
-      Adapters.OBJECT_IDENTIFIER.asTypeHint(),
-      Adapters.BOOLEAN.optional(defaultValue = false),
-      extensionValue,
-      decompose = {
-        listOf(
-            it.id,
-            it.critical,
-            it.value
-        )
-      },
-      construct = {
-        Extension(
-            id = it[0] as String,
-            critical = it[1] as Boolean,
-            value = it[2]
-        )
-      }
+    "Extension",
+    Adapters.OBJECT_IDENTIFIER.asTypeHint(),
+    Adapters.BOOLEAN.optional(defaultValue = false),
+    extensionValue,
+    decompose = {
+      listOf(
+        it.id,
+        it.critical,
+        it.value
+      )
+    },
+    construct = {
+      Extension(
+        id = it[0] as String,
+        critical = it[1] as Boolean,
+        value = it[2]
+      )
+    }
   )
 
   /**
@@ -268,25 +268,25 @@ object CertificateAdapters {
    * ```
    */
   private val attributeTypeAndValue: BasicDerAdapter<AttributeTypeAndValue> = Adapters.sequence(
-      "AttributeTypeAndValue",
-      Adapters.OBJECT_IDENTIFIER,
-      Adapters.any(
-          String::class to Adapters.UTF8_STRING,
-          Nothing::class to Adapters.PRINTABLE_STRING,
-          AnyValue::class to Adapters.ANY_VALUE
-      ),
-      decompose = {
-        listOf(
-            it.type,
-            it.value
-        )
-      },
-      construct = {
-        AttributeTypeAndValue(
-            type = it[0] as String,
-            value = it[1]
-        )
-      }
+    "AttributeTypeAndValue",
+    Adapters.OBJECT_IDENTIFIER,
+    Adapters.any(
+      String::class to Adapters.UTF8_STRING,
+      Nothing::class to Adapters.PRINTABLE_STRING,
+      AnyValue::class to Adapters.ANY_VALUE
+    ),
+    decompose = {
+      listOf(
+        it.type,
+        it.value
+      )
+    },
+    construct = {
+      AttributeTypeAndValue(
+        type = it[0] as String,
+        value = it[1]
+      )
+    }
   )
 
   /**
@@ -308,7 +308,7 @@ object CertificateAdapters {
    * ```
    */
   internal val name: DerAdapter<Pair<DerAdapter<*>, Any?>> = Adapters.choice(
-      rdnSequence
+    rdnSequence
   )
 
   /**
@@ -320,21 +320,21 @@ object CertificateAdapters {
    * ```
    */
   val subjectPublicKeyInfo: BasicDerAdapter<SubjectPublicKeyInfo> = Adapters.sequence(
-      "SubjectPublicKeyInfo",
-      algorithmIdentifier,
-      Adapters.BIT_STRING,
-      decompose = {
-        listOf(
-            it.algorithm,
-            it.subjectPublicKey
-        )
-      },
-      construct = {
-        SubjectPublicKeyInfo(
-            algorithm = it[0] as AlgorithmIdentifier,
-            subjectPublicKey = it[1] as BitString
-        )
-      }
+    "SubjectPublicKeyInfo",
+    algorithmIdentifier,
+    Adapters.BIT_STRING,
+    decompose = {
+      listOf(
+        it.algorithm,
+        it.subjectPublicKey
+      )
+    },
+    construct = {
+      SubjectPublicKeyInfo(
+        algorithm = it[0] as AlgorithmIdentifier,
+        subjectPublicKey = it[1] as BitString
+      )
+    }
   )
 
   /**
@@ -354,45 +354,45 @@ object CertificateAdapters {
    * ```
    */
   val tbsCertificate: BasicDerAdapter<TbsCertificate> = Adapters.sequence(
-      "TBSCertificate",
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 0L).optional(defaultValue = 0), // v1 == 0
-      Adapters.INTEGER_AS_BIG_INTEGER,
-      algorithmIdentifier,
-      name,
-      validity,
-      name,
-      subjectPublicKeyInfo,
-      Adapters.BIT_STRING.withTag(tag = 1L).optional(),
-      Adapters.BIT_STRING.withTag(tag = 2L).optional(),
-      extension.asSequenceOf().withExplicitBox(tag = 3).optional(defaultValue = listOf()),
-      decompose = {
-        listOf(
-            it.version,
-            it.serialNumber,
-            it.signature,
-            rdnSequence to it.issuer,
-            it.validity,
-            rdnSequence to it.subject,
-            it.subjectPublicKeyInfo,
-            it.issuerUniqueID,
-            it.subjectUniqueID,
-            it.extensions
-        )
-      },
-      construct = {
-        TbsCertificate(
-            version = it[0] as Long,
-            serialNumber = it[1] as BigInteger,
-            signature = it[2] as AlgorithmIdentifier,
-            issuer = (it[3] as Pair<*, *>).second as List<List<AttributeTypeAndValue>>,
-            validity = it[4] as Validity,
-            subject = (it[5] as Pair<*, *>).second as List<List<AttributeTypeAndValue>>,
-            subjectPublicKeyInfo = it[6] as SubjectPublicKeyInfo,
-            issuerUniqueID = it[7] as BitString?,
-            subjectUniqueID = it[8] as BitString?,
-            extensions = it[9] as List<Extension>
-        )
-      }
+    "TBSCertificate",
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 0L).optional(defaultValue = 0), // v1 == 0
+    Adapters.INTEGER_AS_BIG_INTEGER,
+    algorithmIdentifier,
+    name,
+    validity,
+    name,
+    subjectPublicKeyInfo,
+    Adapters.BIT_STRING.withTag(tag = 1L).optional(),
+    Adapters.BIT_STRING.withTag(tag = 2L).optional(),
+    extension.asSequenceOf().withExplicitBox(tag = 3).optional(defaultValue = listOf()),
+    decompose = {
+      listOf(
+        it.version,
+        it.serialNumber,
+        it.signature,
+        rdnSequence to it.issuer,
+        it.validity,
+        rdnSequence to it.subject,
+        it.subjectPublicKeyInfo,
+        it.issuerUniqueID,
+        it.subjectUniqueID,
+        it.extensions
+      )
+    },
+    construct = {
+      TbsCertificate(
+        version = it[0] as Long,
+        serialNumber = it[1] as BigInteger,
+        signature = it[2] as AlgorithmIdentifier,
+        issuer = (it[3] as Pair<*, *>).second as List<List<AttributeTypeAndValue>>,
+        validity = it[4] as Validity,
+        subject = (it[5] as Pair<*, *>).second as List<List<AttributeTypeAndValue>>,
+        subjectPublicKeyInfo = it[6] as SubjectPublicKeyInfo,
+        issuerUniqueID = it[7] as BitString?,
+        subjectUniqueID = it[8] as BitString?,
+        extensions = it[9] as List<Extension>
+      )
+    }
   )
 
   /**
@@ -405,24 +405,24 @@ object CertificateAdapters {
    * ```
    */
   val certificate: BasicDerAdapter<Certificate> = Adapters.sequence(
-      "Certificate",
-      tbsCertificate,
-      algorithmIdentifier,
-      Adapters.BIT_STRING,
-      decompose = {
-        listOf(
-            it.tbsCertificate,
-            it.signatureAlgorithm,
-            it.signatureValue
-        )
-      },
-      construct = {
-        Certificate(
-            tbsCertificate = it[0] as TbsCertificate,
-            signatureAlgorithm = it[1] as AlgorithmIdentifier,
-            signatureValue = it[2] as BitString
-        )
-      }
+    "Certificate",
+    tbsCertificate,
+    algorithmIdentifier,
+    Adapters.BIT_STRING,
+    decompose = {
+      listOf(
+        it.tbsCertificate,
+        it.signatureAlgorithm,
+        it.signatureValue
+      )
+    },
+    construct = {
+      Certificate(
+        tbsCertificate = it[0] as TbsCertificate,
+        signatureAlgorithm = it[1] as AlgorithmIdentifier,
+        signatureValue = it[2] as BitString
+      )
+    }
   )
 
   /**
@@ -447,24 +447,24 @@ object CertificateAdapters {
    * ```
    */
   internal val privateKeyInfo: BasicDerAdapter<PrivateKeyInfo> = Adapters.sequence(
-      "PrivateKeyInfo",
-      Adapters.INTEGER_AS_LONG,
-      algorithmIdentifier,
-      Adapters.OCTET_STRING,
-      decompose = {
-        listOf(
-            it.version,
-            it.algorithmIdentifier,
-            it.privateKey
-        )
-      },
-      construct = {
-        PrivateKeyInfo(
-            version = it[0] as Long,
-            algorithmIdentifier = it[1] as AlgorithmIdentifier,
-            privateKey = it[2] as ByteString
-        )
-      }
+    "PrivateKeyInfo",
+    Adapters.INTEGER_AS_LONG,
+    algorithmIdentifier,
+    Adapters.OCTET_STRING,
+    decompose = {
+      listOf(
+        it.version,
+        it.algorithmIdentifier,
+        it.privateKey
+      )
+    },
+    construct = {
+      PrivateKeyInfo(
+        version = it[0] as Long,
+        algorithmIdentifier = it[1] as AlgorithmIdentifier,
+        privateKey = it[2] as ByteString
+      )
+    }
   )
 
   /**

--- a/certifikit/src/main/kotlin/app/cash/certifikit/DerAdapter.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/DerAdapter.kt
@@ -90,10 +90,10 @@ internal interface DerAdapter<T> {
     }
 
     return BasicDerAdapter(
-        name = "EXPLICIT",
-        tagClass = tagClass,
-        tag = tag,
-        codec = codec
+      name = "EXPLICIT",
+      tagClass = tagClass,
+      tag = tag,
+      codec = codec
     )
   }
 
@@ -125,9 +125,9 @@ internal interface DerAdapter<T> {
   /** Returns an adapter that returns a set of values of this type. */
   fun asSetOf(): BasicDerAdapter<List<T>> {
     return asSequenceOf(
-        name = "SET OF",
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 17L
+      name = "SET OF",
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 17L
     )
   }
 }

--- a/certifikit/src/main/kotlin/app/cash/certifikit/DerReader.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/DerReader.kt
@@ -15,14 +15,14 @@
  */
 package app.cash.certifikit
 
-import java.math.BigInteger
-import java.net.ProtocolException
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
 import okio.ForwardingSource
 import okio.Source
 import okio.buffer
+import java.math.BigInteger
+import java.net.ProtocolException
 
 /**
  * Streaming decoder of data encoded following Abstract Syntax Notation One (ASN.1). There are
@@ -321,10 +321,10 @@ class DerReader(source: Source) {
      * value.
      */
     private val END_OF_DATA = DerHeader(
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = DerHeader.TAG_END_OF_CONTENTS,
-        constructed = false,
-        length = -1L
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = DerHeader.TAG_END_OF_CONTENTS,
+      constructed = false,
+      length = -1L
     )
   }
 

--- a/certifikit/src/main/kotlin/app/cash/certifikit/DerWriter.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/DerWriter.kt
@@ -15,10 +15,10 @@
  */
 package app.cash.certifikit
 
-import java.math.BigInteger
 import okio.Buffer
 import okio.BufferedSink
 import okio.ByteString
+import java.math.BigInteger
 
 class DerWriter(sink: BufferedSink) {
   /** A stack of buffers that will be concatenated once we know the length of each. */
@@ -161,8 +161,8 @@ class DerWriter(sink: BufferedSink) {
   fun writeRelativeObjectIdentifier(s: String) {
     // Add a leading dot so each subidentifier has a dot prefix.
     val utf8 = Buffer()
-        .writeByte('.'.toByte().toInt())
-        .writeUtf8(s)
+      .writeByte('.'.toByte().toInt())
+      .writeUtf8(s)
 
     while (!utf8.exhausted()) {
       require(utf8.readByte() == '.'.toByte())

--- a/certifikit/src/main/kotlin/app/cash/certifikit/ExtKeyUsage.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/ExtKeyUsage.kt
@@ -21,21 +21,21 @@ data class ExtKeyUsage(val objectIdentifier: String) {
   }
 
   val name: String?
-  get() {
-    return Known[objectIdentifier]
-  }
+    get() {
+      return Known[objectIdentifier]
+    }
 
   companion object {
     val Known = mapOf(
-        "1.3.6.1.5.5.7.3.1" to "serverAuth",
-        "1.3.6.1.5.5.7.3.2" to "clientAuth",
-        "1.3.6.1.5.5.7.3.3" to "codeSigning",
-        "1.3.6.1.5.5.7.3.4" to "emailProtection",
-        "1.3.6.1.5.5.7.3.8" to "timeStamping",
-        "1.3.6.1.5.5.7.3.9" to "ocspSigning",
-        "1.3.6.1.5.5.7.3.5" to "ipsecEndSystem",
-        "1.3.6.1.5.5.7.3.6" to "ipsecTunnel",
-        "1.3.6.1.5.5.7.3.7" to "ipsecUser"
+      "1.3.6.1.5.5.7.3.1" to "serverAuth",
+      "1.3.6.1.5.5.7.3.2" to "clientAuth",
+      "1.3.6.1.5.5.7.3.3" to "codeSigning",
+      "1.3.6.1.5.5.7.3.4" to "emailProtection",
+      "1.3.6.1.5.5.7.3.8" to "timeStamping",
+      "1.3.6.1.5.5.7.3.9" to "ocspSigning",
+      "1.3.6.1.5.5.7.3.5" to "ipsecEndSystem",
+      "1.3.6.1.5.5.7.3.6" to "ipsecTunnel",
+      "1.3.6.1.5.5.7.3.7" to "ipsecUser"
     )
   }
 }

--- a/certifikit/src/main/kotlin/app/cash/certifikit/attestation/Attestation.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/attestation/Attestation.kt
@@ -159,226 +159,226 @@ data class AuthorizationList(
 
 object AttestationAdapters {
   internal val rootOfTrust = Adapters.sequence(
-      "rootOfTrust",
-      Adapters.OCTET_STRING,
-      Adapters.BOOLEAN,
-      Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
-      Adapters.OCTET_STRING,
-      decompose = {
-        listOf(
-            it.verifiedBootKey,
-            it.deviceLocked,
-            it.verifiedBootState,
-            it.verifiedBootHash
-        )
-      },
-      construct = {
-        RootOfTrust(
-            verifiedBootKey = it[0] as ByteString,
-            deviceLocked = it[1] as Boolean,
-            verifiedBootState = it[2] as Long,
-            verifiedBootHash = it[3] as ByteString
-        )
-      }
+    "rootOfTrust",
+    Adapters.OCTET_STRING,
+    Adapters.BOOLEAN,
+    Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
+    Adapters.OCTET_STRING,
+    decompose = {
+      listOf(
+        it.verifiedBootKey,
+        it.deviceLocked,
+        it.verifiedBootState,
+        it.verifiedBootHash
+      )
+    },
+    construct = {
+      RootOfTrust(
+        verifiedBootKey = it[0] as ByteString,
+        deviceLocked = it[1] as Boolean,
+        verifiedBootState = it[2] as Long,
+        verifiedBootHash = it[3] as ByteString
+      )
+    }
   )
 
   internal val authorizationList = Adapters.sequence(
-      "authorizationList",
-      Adapters.INTEGER_AS_LONG.asSetOf()
-          .withExplicitBox(tag = 1)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 2)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 3)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.asSetOf()
-          .withExplicitBox(tag = 5)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.asSetOf()
-          .withExplicitBox(tag = 6)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 10)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 200)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 303)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 400)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 401)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 402)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 503)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 504)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 505)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 506)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 507)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 508)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 509)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 600)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 601)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 701)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 702)
-          .optional(),
-      Adapters.NULL.withExplicitBox(tag = 703)
-          .optional(),
-      rootOfTrust.withExplicitBox(tag = 704)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 705)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 706)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 709)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 710)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 711)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 712)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 713)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 714)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 715)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 716)
-          .optional(),
-      Adapters.OCTET_STRING.withExplicitBox(tag = 717)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 718)
-          .optional(),
-      Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 719)
-          .optional(),
-      decompose = {
-        listOf(
-            it.purpose,
-            it.algorithm,
-            it.keySize,
-            it.digest,
-            it.padding,
-            it.ecCurve,
-            it.rsaPublicExponent,
-            it.rollbackResistance,
-            it.activeDateTime,
-            it.originationExpireDateTime,
-            it.usageExpireDateTime,
-            it.noAuthRequired,
-            it.userAuthType,
-            it.authTimeout,
-            it.allowWhileOnBody,
-            it.trustedUserPresenceRequired,
-            it.trustedConfirmationRequired,
-            it.unlockedDeviceRequired,
-            it.allApplications,
-            it.applicationId,
-            it.creationDateTime,
-            it.origin,
-            it.rollbackResistant,
-            it.rootOfTrust,
-            it.osVersion,
-            it.osPatchLevel,
-            it.attestationApplicationId,
-            it.attestationIdBrand,
-            it.attestationIdDevice,
-            it.attestationIdProduct,
-            it.attestationIdSerial,
-            it.attestationIdImei,
-            it.attestationIdMeid,
-            it.attestationIdManufacturer,
-            it.attestationIdModel,
-            it.vendorPatchLevel,
-            it.bootPatchLevel
-        )
-      },
-      construct = {
-        AuthorizationList(
-            purpose = it[0] as List<Long>?,
-            algorithm = it[1] as Long?,
-            keySize = it[2] as Long?,
-            digest = it[3] as List<Long>?,
-            padding = it[4] as List<Long>?,
-            ecCurve = it[5] as Long?,
-            rsaPublicExponent = it[6] as Long?,
-            rollbackResistance = it[7] as Unit?,
-            activeDateTime = it[8] as Long?,
-            originationExpireDateTime = it[9] as Long?,
-            usageExpireDateTime = it[10] as Long?,
-            noAuthRequired = it[11] as Unit?,
-            userAuthType = it[12] as Long?,
-            authTimeout = it[13] as Long?,
-            allowWhileOnBody = it[14] as Unit?,
-            trustedUserPresenceRequired = it[15] as Unit?,
-            trustedConfirmationRequired = it[16] as Unit?,
-            unlockedDeviceRequired = it[17] as Unit?,
-            allApplications = it[18] as Unit?,
-            applicationId = it[19] as ByteString?,
-            creationDateTime = it[20] as Long?,
-            origin = it[21] as Long?,
-            rollbackResistant = it[22] as Unit?,
-            rootOfTrust = it[23] as RootOfTrust?,
-            osVersion = it[24] as Long?,
-            osPatchLevel = it[25] as Long?,
-            attestationApplicationId = it[26] as ByteString?,
-            attestationIdBrand = it[27] as ByteString?,
-            attestationIdDevice = it[28] as ByteString?,
-            attestationIdProduct = it[29] as ByteString?,
-            attestationIdSerial = it[30] as ByteString?,
-            attestationIdImei = it[31] as ByteString?,
-            attestationIdMeid = it[32] as ByteString?,
-            attestationIdManufacturer = it[33] as ByteString?,
-            attestationIdModel = it[34] as ByteString?,
-            vendorPatchLevel = it[35] as Long?,
-            bootPatchLevel = it[36] as Long?
-        )
-      }
+    "authorizationList",
+    Adapters.INTEGER_AS_LONG.asSetOf()
+      .withExplicitBox(tag = 1)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 2)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 3)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.asSetOf()
+      .withExplicitBox(tag = 5)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.asSetOf()
+      .withExplicitBox(tag = 6)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 10)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 200)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 303)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 400)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 401)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 402)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 503)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 504)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 505)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 506)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 507)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 508)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 509)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 600)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 601)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 701)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 702)
+      .optional(),
+    Adapters.NULL.withExplicitBox(tag = 703)
+      .optional(),
+    rootOfTrust.withExplicitBox(tag = 704)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 705)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 706)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 709)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 710)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 711)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 712)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 713)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 714)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 715)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 716)
+      .optional(),
+    Adapters.OCTET_STRING.withExplicitBox(tag = 717)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 718)
+      .optional(),
+    Adapters.INTEGER_AS_LONG.withExplicitBox(tag = 719)
+      .optional(),
+    decompose = {
+      listOf(
+        it.purpose,
+        it.algorithm,
+        it.keySize,
+        it.digest,
+        it.padding,
+        it.ecCurve,
+        it.rsaPublicExponent,
+        it.rollbackResistance,
+        it.activeDateTime,
+        it.originationExpireDateTime,
+        it.usageExpireDateTime,
+        it.noAuthRequired,
+        it.userAuthType,
+        it.authTimeout,
+        it.allowWhileOnBody,
+        it.trustedUserPresenceRequired,
+        it.trustedConfirmationRequired,
+        it.unlockedDeviceRequired,
+        it.allApplications,
+        it.applicationId,
+        it.creationDateTime,
+        it.origin,
+        it.rollbackResistant,
+        it.rootOfTrust,
+        it.osVersion,
+        it.osPatchLevel,
+        it.attestationApplicationId,
+        it.attestationIdBrand,
+        it.attestationIdDevice,
+        it.attestationIdProduct,
+        it.attestationIdSerial,
+        it.attestationIdImei,
+        it.attestationIdMeid,
+        it.attestationIdManufacturer,
+        it.attestationIdModel,
+        it.vendorPatchLevel,
+        it.bootPatchLevel
+      )
+    },
+    construct = {
+      AuthorizationList(
+        purpose = it[0] as List<Long>?,
+        algorithm = it[1] as Long?,
+        keySize = it[2] as Long?,
+        digest = it[3] as List<Long>?,
+        padding = it[4] as List<Long>?,
+        ecCurve = it[5] as Long?,
+        rsaPublicExponent = it[6] as Long?,
+        rollbackResistance = it[7] as Unit?,
+        activeDateTime = it[8] as Long?,
+        originationExpireDateTime = it[9] as Long?,
+        usageExpireDateTime = it[10] as Long?,
+        noAuthRequired = it[11] as Unit?,
+        userAuthType = it[12] as Long?,
+        authTimeout = it[13] as Long?,
+        allowWhileOnBody = it[14] as Unit?,
+        trustedUserPresenceRequired = it[15] as Unit?,
+        trustedConfirmationRequired = it[16] as Unit?,
+        unlockedDeviceRequired = it[17] as Unit?,
+        allApplications = it[18] as Unit?,
+        applicationId = it[19] as ByteString?,
+        creationDateTime = it[20] as Long?,
+        origin = it[21] as Long?,
+        rollbackResistant = it[22] as Unit?,
+        rootOfTrust = it[23] as RootOfTrust?,
+        osVersion = it[24] as Long?,
+        osPatchLevel = it[25] as Long?,
+        attestationApplicationId = it[26] as ByteString?,
+        attestationIdBrand = it[27] as ByteString?,
+        attestationIdDevice = it[28] as ByteString?,
+        attestationIdProduct = it[29] as ByteString?,
+        attestationIdSerial = it[30] as ByteString?,
+        attestationIdImei = it[31] as ByteString?,
+        attestationIdMeid = it[32] as ByteString?,
+        attestationIdManufacturer = it[33] as ByteString?,
+        attestationIdModel = it[34] as ByteString?,
+        vendorPatchLevel = it[35] as Long?,
+        bootPatchLevel = it[36] as Long?
+      )
+    }
   )
 
   internal val keyDescription = Adapters.sequence(
-      "KeyDescription",
-      Adapters.INTEGER_AS_LONG,
-      Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
-      Adapters.INTEGER_AS_LONG,
-      Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
-      Adapters.OCTET_STRING,
-      Adapters.OCTET_STRING,
-      authorizationList,
-      authorizationList,
-      decompose = {
-        listOf(
-            it.attestationVersion,
-            it.attestationSecurityLevel,
-            it.keymasterVersion,
-            it.keymasterSecurityLevel,
-            it.attestationChallenge,
-            it.uniqueId,
-            it.softwareEnforced,
-            it.teeEnforced
-        )
-      },
-      construct = {
-        KeyDescription(
-            attestationVersion = it[0] as Long,
-            attestationSecurityLevel = it[1] as Long,
-            keymasterVersion = it[2] as Long,
-            keymasterSecurityLevel = it[3] as Long,
-            attestationChallenge = it[4] as ByteString,
-            uniqueId = it[5] as ByteString,
-            softwareEnforced = it[6] as AuthorizationList,
-            teeEnforced = it[7] as AuthorizationList
-        )
-      }
+    "KeyDescription",
+    Adapters.INTEGER_AS_LONG,
+    Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
+    Adapters.INTEGER_AS_LONG,
+    Adapters.INTEGER_AS_LONG.withTag(tagClass = TAG_CLASS_UNIVERSAL, tag = 10),
+    Adapters.OCTET_STRING,
+    Adapters.OCTET_STRING,
+    authorizationList,
+    authorizationList,
+    decompose = {
+      listOf(
+        it.attestationVersion,
+        it.attestationSecurityLevel,
+        it.keymasterVersion,
+        it.keymasterSecurityLevel,
+        it.attestationChallenge,
+        it.uniqueId,
+        it.softwareEnforced,
+        it.teeEnforced
+      )
+    },
+    construct = {
+      KeyDescription(
+        attestationVersion = it[0] as Long,
+        attestationSecurityLevel = it[1] as Long,
+        keymasterVersion = it[2] as Long,
+        keymasterSecurityLevel = it[3] as Long,
+        attestationChallenge = it[4] as ByteString,
+        uniqueId = it[5] as ByteString,
+        softwareEnforced = it[6] as AuthorizationList,
+        teeEnforced = it[7] as AuthorizationList
+      )
+    }
   )
 
   const val KEY_DESCRIPTION_OID = "1.3.6.1.4.1.11129.2.1.17"

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -15,6 +15,8 @@
  */
 package app.cash.certifikit
 
+import okio.Buffer
+import okio.ByteString
 import java.math.BigInteger
 import java.security.GeneralSecurityException
 import java.security.PublicKey
@@ -26,8 +28,6 @@ import java.time.Duration
 import java.time.Instant
 import java.time.Period
 import java.time.ZoneId
-import okio.Buffer
-import okio.ByteString
 
 data class Certificate(
   val tbsCertificate: TbsCertificate,
@@ -43,32 +43,32 @@ data class Certificate(
   val commonName: String?
     get() {
       return tbsCertificate.subject
-          .flatten()
-          .firstOrNull { it.type == ObjectIdentifiers.commonName }
-          ?.value as String?
+        .flatten()
+        .firstOrNull { it.type == ObjectIdentifiers.commonName }
+        ?.value as String?
     }
 
   val organizationalUnitName: String?
     get() {
       return tbsCertificate.subject
-          .flatten()
-          .firstOrNull { it.type == ObjectIdentifiers.organizationalUnitName }
-          ?.value as String?
+        .flatten()
+        .firstOrNull { it.type == ObjectIdentifiers.organizationalUnitName }
+        ?.value as String?
     }
 
   val keyUsage: BitString?
     get() {
       return tbsCertificate.extensions
-          .firstOrNull { it.id == ObjectIdentifiers.keyUsage }
-          ?.value as BitString?
+        .firstOrNull { it.id == ObjectIdentifiers.keyUsage }
+        ?.value as BitString?
     }
 
   @Suppress("UNCHECKED_CAST")
   val extKeyUsage: List<ExtKeyUsage>?
     get() {
       val list = tbsCertificate.extensions
-          .firstOrNull { it.id == ObjectIdentifiers.extKeyUsage }
-          ?.value as List<String>?
+        .firstOrNull { it.id == ObjectIdentifiers.extKeyUsage }
+        ?.value as List<String>?
       return list?.map { ExtKeyUsage(it) }
     }
 
@@ -175,22 +175,22 @@ data class Validity(
    * Returns the remaining Period, or null if the certificate is not within the valid period.
    */
   val periodLeft: Period?
-  get() {
-    val now = Instant.now()
+    get() {
+      val now = Instant.now()
 
-    return if (now.isBefore(Instant.ofEpochMilli(notBefore))) {
-      null
-    } else {
-      val notAfterInstant = Instant.ofEpochMilli(notAfter)
-      val left = Duration.between(now, notAfterInstant)
-
-      if (left.isNegative) {
+      return if (now.isBefore(Instant.ofEpochMilli(notBefore))) {
         null
       } else {
-        Period.between(now.atZone(ZoneId.systemDefault()).toLocalDate(), notAfterInstant.atZone(ZoneId.systemDefault()).toLocalDate())
+        val notAfterInstant = Instant.ofEpochMilli(notAfter)
+        val left = Duration.between(now, notAfterInstant)
+
+        if (left.isNegative) {
+          null
+        } else {
+          Period.between(now.atZone(ZoneId.systemDefault()).toLocalDate(), notAfterInstant.atZone(ZoneId.systemDefault()).toLocalDate())
+        }
       }
     }
-  }
 
   // Avoid Long.hashCode(long) which isn't available on Android 5.
   override fun hashCode(): Int {

--- a/certifikit/src/test/kotlin/app/cash/certifikit/Certificates.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/Certificates.kt
@@ -16,12 +16,12 @@
 
 package app.cash.certifikit
 
-import java.security.GeneralSecurityException
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import java.security.GeneralSecurityException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 
 /**
  * Decodes a multiline string that contains a [certificate][certificatePem] which is
@@ -44,8 +44,9 @@ fun String.decodeCertificatePem(): X509Certificate {
   try {
     val certificateFactory = CertificateFactory.getInstance("X.509")
     val certificates = certificateFactory
-        .generateCertificates(
-            Buffer().writeUtf8(this).inputStream())
+      .generateCertificates(
+        Buffer().writeUtf8(this).inputStream()
+      )
 
     return certificates.single() as X509Certificate
   } catch (nsee: NoSuchElementException) {

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -21,14 +21,6 @@ import app.cash.certifikit.ObjectIdentifiers.organizationalUnitName
 import app.cash.certifikit.ObjectIdentifiers.rsaEncryption
 import app.cash.certifikit.ObjectIdentifiers.sha256WithRSAEncryption
 import app.cash.certifikit.ObjectIdentifiers.subjectAlternativeName
-import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.cert.X509Certificate
-import java.security.spec.PKCS8EncodedKeySpec
-import java.security.spec.X509EncodedKeySpec
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.decodeBase64
@@ -37,6 +29,14 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 internal class DerCertificatesTest {
   private val stateOrProvince = "1.3.6.1.4.1.311.60.2.1.2"
@@ -61,7 +61,8 @@ internal class DerCertificatesTest {
 
   @Test
   fun `decode simple certificate`() {
-    val certificateBase64 = """
+    val certificateBase64 =
+      """
         |MIIBmjCCAQOgAwIBAgIBATANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDEwhjYXNo
         |LmFwcDAeFw03MDAxMDEwMDAwMDBaFw03MDAxMDEwMDAwMDFaMBMxETAPBgNVBAMT
         |CGNhc2guYXBwMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCApFHhtrLan28q
@@ -73,7 +74,8 @@ internal class DerCertificatesTest {
         |jaA9VEhgdaVhxBsT2qzUNDsXlOzGsliznDfoqETb
         |""".trimMargin()
     val certificateByteString = certificateBase64.decodeBase64()!!
-    val certificatePem = """
+    val certificatePem =
+      """
         |-----BEGIN CERTIFICATE-----
         |$certificateBase64
         |-----END CERTIFICATE-----
@@ -81,80 +83,85 @@ internal class DerCertificatesTest {
 
     val javaCertificate = certificatePem.decodeCertificatePem()
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
     assertThat(okHttpCertificate.signatureValue.byteString)
-        .isEqualTo(javaCertificate.signature.toByteString())
+      .isEqualTo(javaCertificate.signature.toByteString())
 
     assertThat(okHttpCertificate.publicKeySha256()).isEqualTo(javaCertificate.sha256Hash())
 
-    val publicKeyBytes = ("3081890281810080a451e1b6b2da9f6f2afa8328959b9a4df58103457968c22fab7d81" +
+    val publicKeyBytes = (
+      "3081890281810080a451e1b6b2da9f6f2afa8328959b9a4df58103457968c22fab7d81" +
         "b25a10bba2e5bd7d70278604a140a30e53ceb6986ded72db5260676c8ccdf3d5cae1425533a4aaa772bcf0a9" +
         "bccfb80caddadf4e89bfdbbe302f6e5f20247ec83110e5f51560198900a5d91756a8234988a04c74c45b1084" +
-        "827adfbbf6331243ba977ad70203010001").decodeHex()
-    val signatureBytes = ("36a6515c0a879472edeb373b1b58dc8810ba73d4a0b7341b0ef5825f59fbbb76149e55" +
+        "827adfbbf6331243ba977ad70203010001"
+      ).decodeHex()
+    val signatureBytes = (
+      "36a6515c0a879472edeb373b1b58dc8810ba73d4a0b7341b0ef5825f59fbbb76149e55" +
         "91c2398167eeb667716766c35c223cf15d2fc68d691d79db06b9f1852fd9dd305eaf0f11c90a9c69639da7ea" +
         "415f2216991fa31e4f5c1d90aa42f793201b188da03d54486075a561c41b13daacd4343b1794ecc6b258b39c" +
-        "37e8a844db").decodeHex()
+        "37e8a844db"
+      ).decodeHex()
 
     assertThat(okHttpCertificate).isEqualTo(
-        Certificate(
-            tbsCertificate = TbsCertificate(
-                version = 2L, // v3.
-                serialNumber = BigInteger.ONE,
-                signature = AlgorithmIdentifier(
-                    algorithm = sha256WithRSAEncryption,
-                    parameters = null
-                ),
-                issuer = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "cash.app"
-                        )
-                    )
-                ),
-                validity = Validity(
-                    notBefore = 0L,
-                    notAfter = 1000L
-                ),
-                subject = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "cash.app"
-                        )
-                    )
-                ),
-                subjectPublicKeyInfo = SubjectPublicKeyInfo(
-                    algorithm = AlgorithmIdentifier(
-                        algorithm = rsaEncryption,
-                        parameters = null
-                    ),
-                    subjectPublicKey = BitString(
-                        byteString = publicKeyBytes,
-                        unusedBitsCount = 0
-                    )
-                ),
-                issuerUniqueID = null,
-                subjectUniqueID = null,
-                extensions = listOf()
-            ),
-            signatureAlgorithm = AlgorithmIdentifier(
-                algorithm = sha256WithRSAEncryption,
-                parameters = null
-            ),
-            signatureValue = BitString(
-                byteString = signatureBytes,
-                unusedBitsCount = 0
+      Certificate(
+        tbsCertificate = TbsCertificate(
+          version = 2L, // v3.
+          serialNumber = BigInteger.ONE,
+          signature = AlgorithmIdentifier(
+            algorithm = sha256WithRSAEncryption,
+            parameters = null
+          ),
+          issuer = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "cash.app"
+              )
             )
+          ),
+          validity = Validity(
+            notBefore = 0L,
+            notAfter = 1000L
+          ),
+          subject = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "cash.app"
+              )
+            )
+          ),
+          subjectPublicKeyInfo = SubjectPublicKeyInfo(
+            algorithm = AlgorithmIdentifier(
+              algorithm = rsaEncryption,
+              parameters = null
+            ),
+            subjectPublicKey = BitString(
+              byteString = publicKeyBytes,
+              unusedBitsCount = 0
+            )
+          ),
+          issuerUniqueID = null,
+          subjectUniqueID = null,
+          extensions = listOf()
+        ),
+        signatureAlgorithm = AlgorithmIdentifier(
+          algorithm = sha256WithRSAEncryption,
+          parameters = null
+        ),
+        signatureValue = BitString(
+          byteString = signatureBytes,
+          unusedBitsCount = 0
         )
+      )
     )
   }
 
   @Test
   fun `decode CA certificate`() {
-    val certificateBase64 = """
+    val certificateBase64 =
+      """
         |MIIE/zCCA+egAwIBAgIEUdNARDANBgkqhkiG9w0BAQsFADCBsDELMAkGA1UEBhMC
         |VVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xOTA3BgNVBAsTMHd3dy5lbnRydXN0
         |Lm5ldC9DUFMgaXMgaW5jb3Jwb3JhdGVkIGJ5IHJlZmVyZW5jZTEfMB0GA1UECxMW
@@ -184,7 +191,8 @@ internal class DerCertificatesTest {
         |fWlnPfy4fN5Bh9Bp6roKGHoalUOzeXEodm2h+1dK7E3IDhA=
         |""".trimMargin()
     val certificateByteString = certificateBase64.decodeBase64()!!
-    val certificatePem = """
+    val certificatePem =
+      """
         |-----BEGIN CERTIFICATE-----
         |$certificateBase64
         |-----END CERTIFICATE-----
@@ -192,174 +200,185 @@ internal class DerCertificatesTest {
 
     val javaCertificate = certificatePem.decodeCertificatePem()
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
-    val publicKeyBytes = ("3082010a0282010100ba84b672db9e0c6be299e93001a776ea32b895411ac9da614e58" +
+    val publicKeyBytes = (
+      "3082010a0282010100ba84b672db9e0c6be299e93001a776ea32b895411ac9da614e58" +
         "72cffef68279bf7361060aa527d8b35fd3454e1c72d64e32f2728a0ff78319d06a808000451eb0c7e79abf12" +
         "57271ca3682f0a87bd6a6b0e5e65f31c77d5d4858d7021b4b332e78ba2d5863902b1b8d247cee4c949c43ba7" +
         "defb547d57bef0e86ec279b23a0b55e250981632135c2f7856c1c294b3f25ae4279a9f24d7c6ecd09b2582e3" +
         "ccc2c445c58c977a066b2a119fa90a6e483b6fdbd4111942f78f07bff5535f9c3ef4172ce669ac4e324c6277" +
         "eab7e8e5bb34bc198bae9c51e7b77eb553b13322e56dcf703c1afae29b67b683f48da5af624c4de058ac6434" +
-        "1203f8b68d946324a4710203010001").decodeHex()
-    val signatureBytes = ("693383fc287a6f7def9d55ebc53e7a9d75b3ccc33836d934a2286818ea1e69d3bde7d0" +
+        "1203f8b68d946324a4710203010001"
+      ).decodeHex()
+    val signatureBytes = (
+      "693383fc287a6f7def9d55ebc53e7a9d75b3ccc33836d934a2286818ea1e69d3bde7d0" +
         "77dab800834e4acf6fd1f1c1223f74e4f798499e9bb69ee1db98772d5634b1a83cd9fdc0cdc7bf0503d402c5" +
         "f1e5c6da08a513c7622311d161301d608445ef79a8c62693a4b7cd34b869c513f691b3c9457376b692f6760a" +
         "5be10347b7e9294c913223374a9c35d878fd1d1fe483892480adb7f9cfe45da5d471c4855b701fdb3f1c01eb" +
         "1a45263114cc65bf67decacc3365e54191d737be411a969de68a979da7ceac4e9a3dbd01a06ad94f22008b44" +
         "d569627b2eebccbae7927d69673dfcb87cde4187d069eaba0a187a1a9543b3797128766da1fb574aec4dc80e" +
-        "10").decodeHex()
+        "10"
+      ).decodeHex()
 
     assertThat(okHttpCertificate.signatureValue.byteString)
-        .isEqualTo(javaCertificate.signature.toByteString())
+      .isEqualTo(javaCertificate.signature.toByteString())
 
     assertThat(okHttpCertificate).isEqualTo(
-        Certificate(
-            tbsCertificate = TbsCertificate(
-                version = 2L, // v3.
-                serialNumber = BigInteger("1372799044"),
-                signature = AlgorithmIdentifier(
-                    algorithm = sha256WithRSAEncryption,
-                    parameters = null
-                ),
-                issuer = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = countryName,
-                            value = "US"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationName,
-                            value = "Entrust, Inc."
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "www.entrust.net/CPS is incorporated by reference"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "(c) 2006 Entrust, Inc."
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "Entrust Root Certification Authority"
-                        )
-                    )
-                ),
-                validity = Validity(
-                    notBefore = 1411406097000L,
-                    notAfter = 1727055113000L
-                ),
-                subject = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = countryName,
-                            value = "US"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationName,
-                            value = "Entrust, Inc."
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "See www.entrust.net/legal-terms"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "(c) 2009 Entrust, Inc. - for authorized use only"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "Entrust Root Certification Authority - G2"
-                        )
-                    )
-                ),
-                subjectPublicKeyInfo = SubjectPublicKeyInfo(
-                    algorithm = AlgorithmIdentifier(
-                        algorithm = rsaEncryption,
-                        parameters = null
-                    ),
-                    subjectPublicKey = BitString(
-                        byteString = publicKeyBytes,
-                        unusedBitsCount = 0
-                    )
-                ),
-                issuerUniqueID = null,
-                subjectUniqueID = null,
-                extensions = listOf(
-                    Extension(
-                        id = keyUsage,
-                        critical = true,
-                        value = BitString("06".decodeHex(), unusedBitsCount = 1)
-                    ),
-                    Extension(
-                        id = basicConstraints,
-                        critical = true,
-                        value = BasicConstraints(
-                            ca = true,
-                            maxIntermediateCas = 1L
-                        )
-                    ),
-                    Extension(
-                        id = authorityInfoAccess,
-                        critical = false,
-                        value = ("3025302306082b060105050730018617687474703a2f2f6f6373702e656" +
-                            "e74727573742e6e6574").decodeHex()
-                    ),
-                    Extension(
-                        id = crlDistributionPoints,
-                        critical = false,
-                        value = ("302a3028a026a0248622687474703a2f2f63726c2e656e74727573742e6" +
-                            "e65742f726f6f746361312e63726c").decodeHex()
-                    ),
-                    Extension(
-                        id = certificatePolicies,
-                        critical = false,
-                        value = ("303230300604551d20003028302606082b06010505070201161a6874747" +
-                            "03a2f2f7777772e656e74727573742e6e65742f435053").decodeHex()
-                    ),
-                    Extension(
-                        id = subjectKeyIdentifier,
-                        critical = false,
-                        value = "04146a72267ad01eef7de73b6951d46c8d9f901266ab".decodeHex()
-                    ),
-                    Extension(
-                        id = authorityKeyIdentifier,
-                        critical = false,
-                        value = "301680146890e467a4a65380c78666a4f1f74b43fb84bd6d".decodeHex()
-                    )
-                )
+      Certificate(
+        tbsCertificate = TbsCertificate(
+          version = 2L, // v3.
+          serialNumber = BigInteger("1372799044"),
+          signature = AlgorithmIdentifier(
+            algorithm = sha256WithRSAEncryption,
+            parameters = null
+          ),
+          issuer = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = countryName,
+                value = "US"
+              )
             ),
-            signatureAlgorithm = AlgorithmIdentifier(
-                algorithm = sha256WithRSAEncryption,
-                parameters = null
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationName,
+                value = "Entrust, Inc."
+              )
             ),
-            signatureValue = BitString(
-                byteString = signatureBytes,
-                unusedBitsCount = 0
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "www.entrust.net/CPS is incorporated by reference"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "(c) 2006 Entrust, Inc."
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "Entrust Root Certification Authority"
+              )
             )
+          ),
+          validity = Validity(
+            notBefore = 1411406097000L,
+            notAfter = 1727055113000L
+          ),
+          subject = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = countryName,
+                value = "US"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationName,
+                value = "Entrust, Inc."
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "See www.entrust.net/legal-terms"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "(c) 2009 Entrust, Inc. - for authorized use only"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "Entrust Root Certification Authority - G2"
+              )
+            )
+          ),
+          subjectPublicKeyInfo = SubjectPublicKeyInfo(
+            algorithm = AlgorithmIdentifier(
+              algorithm = rsaEncryption,
+              parameters = null
+            ),
+            subjectPublicKey = BitString(
+              byteString = publicKeyBytes,
+              unusedBitsCount = 0
+            )
+          ),
+          issuerUniqueID = null,
+          subjectUniqueID = null,
+          extensions = listOf(
+            Extension(
+              id = keyUsage,
+              critical = true,
+              value = BitString("06".decodeHex(), unusedBitsCount = 1)
+            ),
+            Extension(
+              id = basicConstraints,
+              critical = true,
+              value = BasicConstraints(
+                ca = true,
+                maxIntermediateCas = 1L
+              )
+            ),
+            Extension(
+              id = authorityInfoAccess,
+              critical = false,
+              value = (
+                "3025302306082b060105050730018617687474703a2f2f6f6373702e656" +
+                  "e74727573742e6e6574"
+                ).decodeHex()
+            ),
+            Extension(
+              id = crlDistributionPoints,
+              critical = false,
+              value = (
+                "302a3028a026a0248622687474703a2f2f63726c2e656e74727573742e6" +
+                  "e65742f726f6f746361312e63726c"
+                ).decodeHex()
+            ),
+            Extension(
+              id = certificatePolicies,
+              critical = false,
+              value = (
+                "303230300604551d20003028302606082b06010505070201161a6874747" +
+                  "03a2f2f7777772e656e74727573742e6e65742f435053"
+                ).decodeHex()
+            ),
+            Extension(
+              id = subjectKeyIdentifier,
+              critical = false,
+              value = "04146a72267ad01eef7de73b6951d46c8d9f901266ab".decodeHex()
+            ),
+            Extension(
+              id = authorityKeyIdentifier,
+              critical = false,
+              value = "301680146890e467a4a65380c78666a4f1f74b43fb84bd6d".decodeHex()
+            )
+          )
+        ),
+        signatureAlgorithm = AlgorithmIdentifier(
+          algorithm = sha256WithRSAEncryption,
+          parameters = null
+        ),
+        signatureValue = BitString(
+          byteString = signatureBytes,
+          unusedBitsCount = 0
         )
+      )
     )
   }
 
   @Test
   fun `decode typical certificate`() {
-    val certificateBase64 = """
+    val certificateBase64 =
+      """
         |MIIHHTCCBgWgAwIBAgIRAL5oALmpH7l6AAAAAFTRMh0wDQYJKoZIhvcNAQELBQAw
         |gboxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1FbnRydXN0LCBJbmMuMSgwJgYDVQQL
         |Ex9TZWUgd3d3LmVudHJ1c3QubmV0L2xlZ2FsLXRlcm1zMTkwNwYDVQQLEzAoYykg
@@ -401,7 +420,8 @@ internal class DerCertificatesTest {
         |Aw==
         |""".trimMargin()
     val certificateByteString = certificateBase64.decodeBase64()!!
-    val certificatePem = """
+    val certificatePem =
+      """
         |-----BEGIN CERTIFICATE-----
         |$certificateBase64
         |-----END CERTIFICATE-----
@@ -409,250 +429,263 @@ internal class DerCertificatesTest {
 
     val javaCertificate = certificatePem.decodeCertificatePem()
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
-    val publicKeyBytes = ("3082010a0282010100aafda24b05af6facacfd1bb82ed4b3d11e300dac6496b1481aa7" +
+    val publicKeyBytes = (
+      "3082010a0282010100aafda24b05af6facacfd1bb82ed4b3d11e300dac6496b1481aa7" +
         "49af1c5874074b423ca31f226c7e435076ddaee0960f44a6914d5611f55208796531fc88e1661b063ecb4f32" +
         "3613ddc37556ca61483b6b455bb16259a4aef1daaf41e869d36bd4c1ddf7a01c877835409955f2ec9427b257" +
         "a4f08d27c10c887e769fc6d5ce98c38d7c28620de8398bdc7ad780d0627955660008381f9a47a868dd42c77d" +
         "4ef6a712894939018f077c09cf876d1572b9cfa367499a6edf9142a8848c6b323b69c22e5eb16842059264e7" +
         "416f78aae075e49ee17c4d2fbb893c3f3d489b4a997ee3c68350498de6acfb2c2dd69dc25b543a1cdce0b726" +
-        "a23e0e6f6e09c6e570f10203010001").decodeHex()
-    val signatureBytes = ("60b5fa4d2b90a92004bb7ee927e6aef48951880121b5dc9bc6bde686e208d332267a38" +
+        "a23e0e6f6e09c6e570f10203010001"
+      ).decodeHex()
+    val signatureBytes = (
+      "60b5fa4d2b90a92004bb7ee927e6aef48951880121b5dc9bc6bde686e208d332267a38" +
         "4bba8da49ced920f9f5abc20c13e2bc84ec4af87669ec0e52678a8f519823bbf5eb108e093433de4df5b0201" +
         "7d8bec3a331ed6eb638c06ee151203d752bff698244b5e6e4c229b79601f0bf73470378a25b7ada1f50cf253" +
         "8509b1149ae74f5ccbd0b41b3359d140c5da0557d0104848627ad4ebbdb1e83fdcc9aeabe54c16c9edd33990" +
         "87d0b87e61a66ab6e2b1f651081176b18c3de3a4697044bb84fdf23a7d783ed2432f6aa3552e6a4d6894fb59" +
         "e1ece5b91fd1d53baed0de7ebd2229ea88c6b95444f81b796645f06024a5d35a0b058c0c014ef031b4e0afad" +
-        "03").decodeHex()
+        "03"
+      ).decodeHex()
 
     assertThat(okHttpCertificate.signatureValue.byteString)
-        .isEqualTo(javaCertificate.signature.toByteString())
+      .isEqualTo(javaCertificate.signature.toByteString())
 
     assertThat(okHttpCertificate).isEqualTo(
-        Certificate(
-            tbsCertificate = TbsCertificate(
-                version = 2L, // v3.
-                serialNumber = BigInteger("253093332781973022312510445874391888413"),
-                signature = AlgorithmIdentifier(
-                    algorithm = sha256WithRSAEncryption,
-                    parameters = null
-                ),
-                issuer = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = countryName,
-                            value = "US"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationName,
-                            value = "Entrust, Inc."
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "See www.entrust.net/legal-terms"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationalUnitName,
-                            value = "(c) 2014 Entrust, Inc. - for authorized use only"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "Entrust Certification Authority - L1M"
-                        )
-                    )
-                ),
-                validity = Validity(
-                    notBefore = 1586784349000L,
-                    notAfter = 1618235749000L
-                ),
-                subject = listOf(
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = countryName,
-                            value = "US"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = stateOrProvinceName,
-                            value = "California"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = localityName,
-                            value = "San Francisco"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = country,
-                            value = "US"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = stateOrProvince,
-                            value = "Delaware"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = organizationName,
-                            value = "Square, Inc."
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = businessCategory,
-                            value = "Private Organization"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = serialNumber,
-                            value = "4699855"
-                        )
-                    ),
-                    listOf(
-                        AttributeTypeAndValue(
-                            type = commonName,
-                            value = "cash.app"
-                        )
-                    )
-                ),
-                subjectPublicKeyInfo = SubjectPublicKeyInfo(
-                    algorithm = AlgorithmIdentifier(
-                        algorithm = rsaEncryption,
-                        parameters = null
-                    ),
-                    subjectPublicKey = BitString(
-                        byteString = publicKeyBytes,
-                        unusedBitsCount = 0
-                    )
-                ),
-                issuerUniqueID = null,
-                subjectUniqueID = null,
-                extensions = listOf(
-                    Extension(
-                        id = subjectAlternativeName,
-                        critical = false,
-                        value = listOf(
-                            CertificateAdapters.generalNameDnsName to "cash.app",
-                            CertificateAdapters.generalNameDnsName to "www.cash.app"
-                        )
-                    ),
-                    Extension(
-                        id = certificateTransparencySignedCertificateTimestamps,
-                        critical = false,
-                        value = ("0482016b01690077005614069a2fd7c2ecd3f5e1bd44b23ec74676b9bc9" +
-                            "9115cc0ef949855d689d0dd0000017173d3269b0000040300483046022100a9e58ad" +
-                            "ee5adf4b5f5a7797480f80dc58041d78da8aad44c9cc0416a74cacb62022100eb463" +
-                            "ecf46c5725dfd50471804e4c665e8ae9790129b69706502a3e96fccf685007700877" +
-                            "5bfe7597cf88c43995fbdf36eff568d475636ff4ab560c1b4eaff5ea0830f0000017" +
-                            "173d326ad0000040300483046022100d452c0099540b5e18716db51348a200e8fd10" +
-                            "e8498d00108d4898d22b943422d022100f3c8677a062a55aca46dbb1049223480fff" +
-                            "e39d9e6fd386ca3a1c42455ef60670075007d3ef2f88fff88556824c2c0ca9e52897" +
-                            "92bc50e78097f2e6a9768997e22f0d70000017173d326b3000004030046304402207" +
-                            "e112c029b93e0db15d1de40eddb9aa7a55eeb4b48ce8c94ddf8ed71331e931e02207" +
-                            "8281e3c39c8e643b901c2bc6c470aa0ed3ad01bf17f0f207dc0f8a5ab541a70")
-                            .decodeHex()
-                    ),
-                    Extension(
-                        id = keyUsage,
-                        critical = true,
-                        value = BitString("a0".decodeHex(), unusedBitsCount = 5)
-                    ),
-                    Extension(
-                        id = extendedKeyUsage,
-                        critical = false,
-                        value = listOf("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2")
-                    ),
-                    Extension(
-                        id = authorityInfoAccess,
-                        critical = false,
-                        value = ("305a302306082b060105050730018617687474703a2f2f6f6373702e656" +
-                            "e74727573742e6e6574303306082b060105050730028627687474703a2f2f6169612" +
-                            "e656e74727573742e6e65742f6c316d2d636861696e3235362e636572").decodeHex()
-                    ),
-                    Extension(
-                        id = crlDistributionPoints,
-                        critical = false,
-                        value = ("302a3028a026a0248622687474703a2f2f63726c2e656e74727573742e6" +
-                            "e65742f6c6576656c316d2e63726c").decodeHex()
-                    ),
-                    Extension(
-                        id = certificatePolicies,
-                        critical = false,
-                        value = ("30413036060a6086480186fa6c0a01023028302606082b0601050507020" +
-                            "1161a687474703a2f2f7777772e656e74727573742e6e65742f72706130070605678" +
-                            "10c0101").decodeHex()
-                    ),
-                    Extension(
-                        id = authorityKeyIdentifier,
-                        critical = false,
-                        value = ("30168014c3f7d0b52a30adaf0d9121703954ddbc8970c73a").decodeHex()
-                    ),
-                    Extension(
-                        id = subjectKeyIdentifier,
-                        critical = false,
-                        value = "041475fd24c2df592599e32f3373e18c0450dd1b87b6".decodeHex()
-                    ),
-                    Extension(
-                        id = basicConstraints,
-                        critical = false,
-                        value = BasicConstraints(
-                            ca = false,
-                            maxIntermediateCas = null
-                        )
-                    )
-                )
+      Certificate(
+        tbsCertificate = TbsCertificate(
+          version = 2L, // v3.
+          serialNumber = BigInteger("253093332781973022312510445874391888413"),
+          signature = AlgorithmIdentifier(
+            algorithm = sha256WithRSAEncryption,
+            parameters = null
+          ),
+          issuer = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = countryName,
+                value = "US"
+              )
             ),
-            signatureAlgorithm = AlgorithmIdentifier(
-                algorithm = sha256WithRSAEncryption,
-                parameters = null
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationName,
+                value = "Entrust, Inc."
+              )
             ),
-            signatureValue = BitString(
-                byteString = signatureBytes,
-                unusedBitsCount = 0
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "See www.entrust.net/legal-terms"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationalUnitName,
+                value = "(c) 2014 Entrust, Inc. - for authorized use only"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "Entrust Certification Authority - L1M"
+              )
             )
+          ),
+          validity = Validity(
+            notBefore = 1586784349000L,
+            notAfter = 1618235749000L
+          ),
+          subject = listOf(
+            listOf(
+              AttributeTypeAndValue(
+                type = countryName,
+                value = "US"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = stateOrProvinceName,
+                value = "California"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = localityName,
+                value = "San Francisco"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = country,
+                value = "US"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = stateOrProvince,
+                value = "Delaware"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = organizationName,
+                value = "Square, Inc."
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = businessCategory,
+                value = "Private Organization"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = serialNumber,
+                value = "4699855"
+              )
+            ),
+            listOf(
+              AttributeTypeAndValue(
+                type = commonName,
+                value = "cash.app"
+              )
+            )
+          ),
+          subjectPublicKeyInfo = SubjectPublicKeyInfo(
+            algorithm = AlgorithmIdentifier(
+              algorithm = rsaEncryption,
+              parameters = null
+            ),
+            subjectPublicKey = BitString(
+              byteString = publicKeyBytes,
+              unusedBitsCount = 0
+            )
+          ),
+          issuerUniqueID = null,
+          subjectUniqueID = null,
+          extensions = listOf(
+            Extension(
+              id = subjectAlternativeName,
+              critical = false,
+              value = listOf(
+                CertificateAdapters.generalNameDnsName to "cash.app",
+                CertificateAdapters.generalNameDnsName to "www.cash.app"
+              )
+            ),
+            Extension(
+              id = certificateTransparencySignedCertificateTimestamps,
+              critical = false,
+              value = (
+                "0482016b01690077005614069a2fd7c2ecd3f5e1bd44b23ec74676b9bc9" +
+                  "9115cc0ef949855d689d0dd0000017173d3269b0000040300483046022100a9e58ad" +
+                  "ee5adf4b5f5a7797480f80dc58041d78da8aad44c9cc0416a74cacb62022100eb463" +
+                  "ecf46c5725dfd50471804e4c665e8ae9790129b69706502a3e96fccf685007700877" +
+                  "5bfe7597cf88c43995fbdf36eff568d475636ff4ab560c1b4eaff5ea0830f0000017" +
+                  "173d326ad0000040300483046022100d452c0099540b5e18716db51348a200e8fd10" +
+                  "e8498d00108d4898d22b943422d022100f3c8677a062a55aca46dbb1049223480fff" +
+                  "e39d9e6fd386ca3a1c42455ef60670075007d3ef2f88fff88556824c2c0ca9e52897" +
+                  "92bc50e78097f2e6a9768997e22f0d70000017173d326b3000004030046304402207" +
+                  "e112c029b93e0db15d1de40eddb9aa7a55eeb4b48ce8c94ddf8ed71331e931e02207" +
+                  "8281e3c39c8e643b901c2bc6c470aa0ed3ad01bf17f0f207dc0f8a5ab541a70"
+                )
+                .decodeHex()
+            ),
+            Extension(
+              id = keyUsage,
+              critical = true,
+              value = BitString("a0".decodeHex(), unusedBitsCount = 5)
+            ),
+            Extension(
+              id = extendedKeyUsage,
+              critical = false,
+              value = listOf("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2")
+            ),
+            Extension(
+              id = authorityInfoAccess,
+              critical = false,
+              value = (
+                "305a302306082b060105050730018617687474703a2f2f6f6373702e656" +
+                  "e74727573742e6e6574303306082b060105050730028627687474703a2f2f6169612" +
+                  "e656e74727573742e6e65742f6c316d2d636861696e3235362e636572"
+                ).decodeHex()
+            ),
+            Extension(
+              id = crlDistributionPoints,
+              critical = false,
+              value = (
+                "302a3028a026a0248622687474703a2f2f63726c2e656e74727573742e6" +
+                  "e65742f6c6576656c316d2e63726c"
+                ).decodeHex()
+            ),
+            Extension(
+              id = certificatePolicies,
+              critical = false,
+              value = (
+                "30413036060a6086480186fa6c0a01023028302606082b0601050507020" +
+                  "1161a687474703a2f2f7777772e656e74727573742e6e65742f72706130070605678" +
+                  "10c0101"
+                ).decodeHex()
+            ),
+            Extension(
+              id = authorityKeyIdentifier,
+              critical = false,
+              value = ("30168014c3f7d0b52a30adaf0d9121703954ddbc8970c73a").decodeHex()
+            ),
+            Extension(
+              id = subjectKeyIdentifier,
+              critical = false,
+              value = "041475fd24c2df592599e32f3373e18c0450dd1b87b6".decodeHex()
+            ),
+            Extension(
+              id = basicConstraints,
+              critical = false,
+              value = BasicConstraints(
+                ca = false,
+                maxIntermediateCas = null
+              )
+            )
+          )
+        ),
+        signatureAlgorithm = AlgorithmIdentifier(
+          algorithm = sha256WithRSAEncryption,
+          parameters = null
+        ),
+        signatureValue = BitString(
+          byteString = signatureBytes,
+          unusedBitsCount = 0
         )
+      )
     )
   }
 
   @Test
   fun `certificate attributes`() {
     val certificate = HeldCertificate.Builder()
-        .certificateAuthority(3)
-        .commonName("Jurassic Park")
-        .organizationalUnit("Gene Research")
-        .addSubjectAlternativeName("*.example.com")
-        .addSubjectAlternativeName("www.example.org")
-        .validityInterval(-1000L, 2000L)
-        .serialNumber(17L)
-        .build()
+      .certificateAuthority(3)
+      .commonName("Jurassic Park")
+      .organizationalUnit("Gene Research")
+      .addSubjectAlternativeName("*.example.com")
+      .addSubjectAlternativeName("www.example.org")
+      .validityInterval(-1000L, 2000L)
+      .serialNumber(17L)
+      .build()
 
     val certificateByteString = certificate.certificate.encoded.toByteString()
 
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
     assertThat(okHttpCertificate.basicConstraints).isEqualTo(BasicConstraints(true, 3))
     assertThat(okHttpCertificate.commonName).isEqualTo("Jurassic Park")
     assertThat(okHttpCertificate.organizationalUnitName).isEqualTo("Gene Research")
-    assertThat(okHttpCertificate.subjectAlternativeNames).isEqualTo(listOf(
-            CertificateAdapters.generalNameDnsName to "*.example.com",
-            CertificateAdapters.generalNameDnsName to "www.example.org"
-        )
+    assertThat(okHttpCertificate.subjectAlternativeNames).isEqualTo(
+      listOf(
+        CertificateAdapters.generalNameDnsName to "*.example.com",
+        CertificateAdapters.generalNameDnsName to "www.example.org"
+      )
     )
     assertThat(okHttpCertificate.tbsCertificate.validity).isEqualTo(Validity(-1000L, 2000L))
     assertThat(okHttpCertificate.tbsCertificate.serialNumber).isEqualTo(BigInteger("17"))
@@ -661,17 +694,17 @@ internal class DerCertificatesTest {
   @Test
   fun `missing subject alternative names`() {
     val certificate = HeldCertificate.Builder()
-        .certificateAuthority(3)
-        .commonName("Jurassic Park")
-        .organizationalUnit("Gene Research")
-        .validityInterval(-1000L, 2000L)
-        .serialNumber(17L)
-        .build()
+      .certificateAuthority(3)
+      .commonName("Jurassic Park")
+      .organizationalUnit("Gene Research")
+      .validityInterval(-1000L, 2000L)
+      .serialNumber(17L)
+      .build()
 
     val certificateByteString = certificate.certificate.encoded.toByteString()
 
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
     assertThat(okHttpCertificate.commonName).isEqualTo("Jurassic Park")
     assertThat(okHttpCertificate.subjectAlternativeNames).isNull()
@@ -679,10 +712,13 @@ internal class DerCertificatesTest {
 
   @Test
   fun `public key`() {
-    val publicKeyBytes = ("MIGJAoGBAICkUeG2stqfbyr6gyiVm5pN9YEDRXlowi+rfYGyWhC7ouW9fXAnhgShQKMOU8" +
+    val publicKeyBytes = (
+      "MIGJAoGBAICkUeG2stqfbyr6gyiVm5pN9YEDRXlowi+rfYGyWhC7ouW9fXAnhgShQKMOU8" +
         "62mG3tcttSYGdsjM3z1crhQlUzpKqncrzwqbzPuAyt2t9Oib/bvjAvbl8gJH7IMRDl9RVgGYkApdkXVqgjSYigTH" +
-        "TEWxCEgnrfu/YzEkO6l3rXAgMBAAE=").decodeBase64()!!
-    val privateKeyBytes = ("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAICkUeG2stqfbyr6gyiVm" +
+        "TEWxCEgnrfu/YzEkO6l3rXAgMBAAE="
+      ).decodeBase64()!!
+    val privateKeyBytes = (
+      "MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAICkUeG2stqfbyr6gyiVm" +
         "5pN9YEDRXlowi+rfYGyWhC7ouW9fXAnhgShQKMOU862mG3tcttSYGdsjM3z1crhQlUzpKqncrzwqbzPuAyt2t9Oi" +
         "b/bvjAvbl8gJH7IMRDl9RVgGYkApdkXVqgjSYigTHTEWxCEgnrfu/YzEkO6l3rXAgMBAAECgYB99mhnB6piADOud" +
         "dXv626NzUBTr4xbsYRTgSxHzwf50oFTTBSDuW+1IOBVyTWu94SSPyt0LllPbC8Di3sQSTnVGpSqAvEXknBMzIc0U" +
@@ -691,27 +727,28 @@ internal class DerCertificatesTest {
         "IX2gcNZr1B/V3zcGlolTDciRm+fnKGNt2EEDKnVL3swzbEfTCa48IT0QKgZJqpXZERa26UHAkBLXmiP5f5pk8F3w" +
         "cXzAeVw06z3k1IB41Tu6MX+CyPU+TeudRlz+wV8b0zDvK+EnRKCCbptVFj1Bkt8lQ4JfcnhAkAk2Y3Gz+HySrkcT" +
         "7Cg12M/NkdUQnZe3jr88pt/+IGNwomc6Wt/mJ4fcWONTkGMcfOZff1NQeNXDAZ6941XCsIVAkASOg02PlVHLidU7" +
-        "mIE65swMM5/RNhS4aFjez/MwxFNOHaxc9VgCwYPXCLOtdf7AVovdyG0XWgbUXH+NyxKwboE").decodeBase64()!!
+        "mIE65swMM5/RNhS4aFjez/MwxFNOHaxc9VgCwYPXCLOtdf7AVovdyG0XWgbUXH+NyxKwboE"
+      ).decodeBase64()!!
 
     val x509PublicKey = encodeKey(
-        algorithm = rsaEncryption,
-        publicKeyBytes = publicKeyBytes
+      algorithm = rsaEncryption,
+      publicKeyBytes = publicKeyBytes
     )
     val keyFactory = KeyFactory.getInstance("RSA")
     val publicKey = keyFactory.generatePublic(X509EncodedKeySpec(x509PublicKey.toByteArray()))
     val privateKey = keyFactory.generatePrivate(PKCS8EncodedKeySpec(privateKeyBytes.toByteArray()))
 
     val certificate = HeldCertificate.Builder()
-        .keyPair(publicKey, privateKey)
-        .build()
+      .keyPair(publicKey, privateKey)
+      .build()
 
     val certificateByteString = certificate.certificate.encoded.toByteString()
 
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
     assertThat(okHttpCertificate.tbsCertificate.subjectPublicKeyInfo.subjectPublicKey)
-        .isEqualTo(BitString(publicKeyBytes, 0))
+      .isEqualTo(BitString(publicKeyBytes, 0))
   }
 
   @Test fun `time before 2050 uses UTC_TIME`() {
@@ -757,13 +794,15 @@ internal class DerCertificatesTest {
 
   @Test
   fun `reencode golden EC certificate`() {
-    val certificateByteString = ("MIIBkjCCATmgAwIBAgIBETAKBggqhkjOPQQDAjAwMRYwFAYDVQQLDA1HZW5lIFJ" +
+    val certificateByteString = (
+      "MIIBkjCCATmgAwIBAgIBETAKBggqhkjOPQQDAjAwMRYwFAYDVQQLDA1HZW5lIFJ" +
         "lc2VhcmNoMRYwFAYDVQQDDA1KdXJhc3NpYyBQYXJrMB4XDTY5MTIzMTIzNTk1OVoXDTcwMDEwMTAwMDAwMlowMDE" +
         "WMBQGA1UECwwNR2VuZSBSZXNlYXJjaDEWMBQGA1UEAwwNSnVyYXNzaWMgUGFyazBZMBMGByqGSM49AgEGCCqGSM4" +
         "9AwEHA0IABKzhiMzpN+BkUSPLIKItu6O2iao2Pd7dxrvPdIs4xv9/2tPCVgUxevZ27qRcqZOnSd31ZP6B04vkXag" +
         "/awy2/iujRDBCMBIGA1UdEwEB/wQIMAYBAf8CAQMwLAYDVR0RAQH/BCIwIIINKi5leGFtcGxlLmNvbYIPd3d3LmV" +
         "4YW1wbGUub3JnMAoGCCqGSM49BAMCA0cAMEQCIHzutN/uzViLBXZ0slMqO5oz7ghgBgDbgo2ZyroVeQ/KAiB6Vqo" +
-        "QXETXce4IZyv3mwGWYePlXU2yMXtezbNluXqUxQ==").decodeBase64()!!
+        "QXETXce4IZyv3mwGWYePlXU2yMXtezbNluXqUxQ=="
+      ).decodeBase64()!!
 
     val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
     val encoded = CertificateAdapters.certificate.toDer(decoded)
@@ -773,7 +812,8 @@ internal class DerCertificatesTest {
 
   @Test
   fun `reencode golden RSA certificate`() {
-    val certificateByteString = ("MIIDHzCCAgegAwIBAgIBETANBgkqhkiG9w0BAQsFADAwMRYwFAYDVQQLDA1HZW5" +
+    val certificateByteString = (
+      "MIIDHzCCAgegAwIBAgIBETANBgkqhkiG9w0BAQsFADAwMRYwFAYDVQQLDA1HZW5" +
         "lIFJlc2VhcmNoMRYwFAYDVQQDDA1KdXJhc3NpYyBQYXJrMB4XDTY5MTIzMTIzNTk1OVoXDTcwMDEwMTAwMDAwMlo" +
         "wMDEWMBQGA1UECwwNR2VuZSBSZXNlYXJjaDEWMBQGA1UEAwwNSnVyYXNzaWMgUGFyazCCASIwDQYJKoZIhvcNAQE" +
         "BBQADggEPADCCAQoCggEBAMfROxfCzmxIX5bDSZt6hstXALVeiywFFzTLW5UI0eKSDCliojmiKBcGR5ln7gVe6/t" +
@@ -785,7 +825,8 @@ internal class DerCertificatesTest {
         "0QHZ6UGtJwvVBqY187xg9whytqdMFmadCp8FQT/dLRUn27gtQLOju4FfA3yetJ5oWjbgkaAr7YGP7Auz3o+w51aa" +
         "YpseFTZ/zABwnADSiHCIl35TGZJa1XOl32+RWn9VhT92zm3R12FMBovpMFaDckSJAi0jhMHm/QsFK66V0DZxdvl9" +
         "LX/UI7q870lojkolCmDJfftAnd2eazoY/O3TqP/duRH522U+C42nXRg9y0CFgzVWmee4EzsCHhkeHUDbsijgSHd4" +
-        "vjraGi943vN59SjQrflkISUnOqChOaWP0oSztRUA=").decodeBase64()!!
+        "vjraGi943vN59SjQrflkISUnOqChOaWP0oSztRUA="
+      ).decodeBase64()!!
 
     val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
     val encoded = CertificateAdapters.certificate.toDer(decoded)
@@ -795,7 +836,8 @@ internal class DerCertificatesTest {
 
   @Test
   fun `private key info`() {
-    val privateKeyInfoByteString = ("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAICkUeG2stqf" +
+    val privateKeyInfoByteString = (
+      "MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAICkUeG2stqf" +
         "byr6gyiVm5pN9YEDRXlowi+rfYGyWhC7ouW9fXAnhgShQKMOU862mG3tcttSYGdsjM3z1crhQlUzpKqncrzwqbzP" +
         "uAyt2t9Oib/bvjAvbl8gJH7IMRDl9RVgGYkApdkXVqgjSYigTHTEWxCEgnrfu/YzEkO6l3rXAgMBAAECgYB99mhn" +
         "B6piADOuddXv626NzUBTr4xbsYRTgSxHzwf50oFTTBSDuW+1IOBVyTWu94SSPyt0LllPbC8Di3sQSTnVGpSqAvEX" +
@@ -804,8 +846,9 @@ internal class DerCertificatesTest {
         "7NIM0qZ/gIX2gcNZr1B/V3zcGlolTDciRm+fnKGNt2EEDKnVL3swzbEfTCa48IT0QKgZJqpXZERa26UHAkBLXmiP" +
         "5f5pk8F3wcXzAeVw06z3k1IB41Tu6MX+CyPU+TeudRlz+wV8b0zDvK+EnRKCCbptVFj1Bkt8lQ4JfcnhAkAk2Y3G" +
         "z+HySrkcT7Cg12M/NkdUQnZe3jr88pt/+IGNwomc6Wt/mJ4fcWONTkGMcfOZff1NQeNXDAZ6941XCsIVAkASOg02" +
-        "PlVHLidU7mIE65swMM5/RNhS4aFjez/MwxFNOHaxc9VgCwYPXCLOtdf7AVovdyG0XWgbUXH+NyxKwboE")
-        .decodeBase64()!!
+        "PlVHLidU7mIE65swMM5/RNhS4aFjez/MwxFNOHaxc9VgCwYPXCLOtdf7AVovdyG0XWgbUXH+NyxKwboE"
+      )
+      .decodeBase64()!!
 
     val decoded = CertificateAdapters.privateKeyInfo.fromDer(privateKeyInfoByteString)
 
@@ -820,27 +863,27 @@ internal class DerCertificatesTest {
   @Test
   fun `RSA issuer and signature`() {
     val root = HeldCertificate.Builder()
-        .certificateAuthority(0)
-        .rsa2048()
-        .build()
+      .certificateAuthority(0)
+      .rsa2048()
+      .build()
     val certificate = HeldCertificate.Builder()
-        .signedBy(root)
-        .rsa2048()
-        .build()
+      .signedBy(root)
+      .rsa2048()
+      .build()
 
     val certificateByteString = certificate.certificate.encoded.toByteString()
 
     // Valid signature.
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
     println(okHttpCertificate)
     assertThat(okHttpCertificate.checkSignature(root.keyPair.public)).isTrue()
 
     // Invalid signature.
     val okHttpCertificateWithBadSignature = okHttpCertificate.copy(
-        signatureValue = okHttpCertificate.signatureValue.copy(
-            byteString = okHttpCertificate.signatureValue.byteString.offByOneBit()
-        )
+      signatureValue = okHttpCertificate.signatureValue.copy(
+        byteString = okHttpCertificate.signatureValue.byteString.offByOneBit()
+      )
     )
     assertThat(okHttpCertificateWithBadSignature.checkSignature(root.keyPair.public)).isFalse()
 
@@ -851,26 +894,26 @@ internal class DerCertificatesTest {
   @Test
   fun `EC issuer and signature`() {
     val root = HeldCertificate.Builder()
-        .certificateAuthority(0)
-        .ecdsa256()
-        .build()
+      .certificateAuthority(0)
+      .ecdsa256()
+      .build()
     val certificate = HeldCertificate.Builder()
-        .signedBy(root)
-        .ecdsa256()
-        .build()
+      .signedBy(root)
+      .ecdsa256()
+      .build()
 
     val certificateByteString = certificate.certificate.encoded.toByteString()
 
     // Valid signature.
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
     assertThat(okHttpCertificate.checkSignature(root.keyPair.public)).isTrue()
 
     // Invalid signature.
     val okHttpCertificateWithBadSignature = okHttpCertificate.copy(
-        signatureValue = okHttpCertificate.signatureValue.copy(
-            byteString = okHttpCertificate.signatureValue.byteString.offByOneBit()
-        )
+      signatureValue = okHttpCertificate.signatureValue.copy(
+        byteString = okHttpCertificate.signatureValue.byteString.offByOneBit()
+      )
     )
     assertThat(okHttpCertificateWithBadSignature.checkSignature(root.keyPair.public)).isFalse()
 
@@ -884,7 +927,8 @@ internal class DerCertificatesTest {
    */
   @Test
   fun `unsupported general name tag`() {
-    val certificateByteString = ("MIIFEDCCA/igAwIBAgIRAJK4dE9xztDibHKj2NXZJbIwDQYJKoZIhvcNAQELBQA" +
+    val certificateByteString = (
+      "MIIFEDCCA/igAwIBAgIRAJK4dE9xztDibHKj2NXZJbIwDQYJKoZIhvcNAQELBQA" +
         "wSDELMAkGA1UEBhMCVVMxIDAeBgNVBAoTF1NlY3VyZVRydXN0IENvcnBvcmF0aW9uMRcwFQYDVQQDEw5TZWN1cmV" +
         "UcnVzdCBDQTAeFw0xNjA5MDExNDM1MzVaFw0yNDA5MjkxNDM1MzVaMIG1MQswCQYDVQQGEwJVUzERMA8GA1UECBM" +
         "ISWxsaW5vaXMxEDAOBgNVBAcTB0NoaWNhZ28xITAfBgNVBAoTGFRydXN0d2F2ZSBIb2xkaW5ncywgSW5jLjE9MDs" +
@@ -903,27 +947,29 @@ internal class DerCertificatesTest {
         "FAAOCAQEAC0OvN7/UJBcRDXchA4b2qJo7mBD05+XR96N7vucMaanz26CnUxs1o8DcBckpqyEXCxdOanIr+/UJNbB" +
         "LXLJCzNLJEJcgV9TjbVu33eQR23yMuXD+cZsqLMF+L5IIM47W8dlwKJvMy0xs7Jb1S3NOIhcoVu+XPzRsgKv8Yi2" +
         "B6l278RfzegiCx4vYJv0pBjFzizEiFH9bWTYIOlIJJSM57hoICgjCTS8BoEgndwWIyc/nEmlYaUwmCo9QynY+UmW" +
-        "1WPWmVITEJPMdMK6AZqvvaWmuHJ6/vURaz+Hoc5D3z0yJDDCkv52bXV04ZoF6cbcWry7JvNA+djvay/4BRR4SZQ==")
-        .decodeBase64()!!
+        "1WPWmVITEJPMdMK6AZqvvaWmuHJ6/vURaz+Hoc5D3z0yJDDCkv52bXV04ZoF6cbcWry7JvNA+djvay/4BRR4SZQ=="
+      )
+      .decodeBase64()!!
 
     val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
-    assertThat(decoded.subjectAlternativeNames).isEqualTo(listOf(
-            Adapters.ANY_VALUE to AnyValue(
-                tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
-                tag = 1L,
-                constructed = false,
-                length = 16,
-                bytes = "ca@trustwave.com".encodeUtf8()
-            )
+    assertThat(decoded.subjectAlternativeNames).isEqualTo(
+      listOf(
+        Adapters.ANY_VALUE to AnyValue(
+          tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
+          tag = 1L,
+          constructed = false,
+          length = 16,
+          bytes = "ca@trustwave.com".encodeUtf8()
         )
+      )
     )
   }
 
   /** Converts public key bytes to SubjectPublicKeyInfo bytes. */
   private fun encodeKey(algorithm: String, publicKeyBytes: ByteString): ByteString {
     val subjectPublicKeyInfo = SubjectPublicKeyInfo(
-        algorithm = AlgorithmIdentifier(algorithm = algorithm, parameters = null),
-        subjectPublicKey = BitString(publicKeyBytes, 0)
+      algorithm = AlgorithmIdentifier(algorithm = algorithm, parameters = null),
+      subjectPublicKey = BitString(publicKeyBytes, 0)
     )
     return CertificateAdapters.subjectPublicKeyInfo.toDer(subjectPublicKeyInfo)
   }
@@ -931,9 +977,9 @@ internal class DerCertificatesTest {
   /** Returns a byte string that differs from this one by one bit. */
   private fun ByteString.offByOneBit(): ByteString {
     return Buffer()
-        .write(this, 0, size - 1)
-        .writeByte(this[size - 1].toInt() xor 1)
-        .readByteString()
+      .write(this, 0, size - 1)
+      .writeByte(this[size - 1].toInt() xor 1)
+      .readByteString()
   }
 
   private fun date(s: String): Date {

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerTest.kt
@@ -21,12 +21,6 @@ import app.cash.certifikit.ObjectIdentifiers.basicConstraints
 import app.cash.certifikit.ObjectIdentifiers.commonName
 import app.cash.certifikit.ObjectIdentifiers.sha256WithRSAEncryption
 import app.cash.certifikit.ObjectIdentifiers.subjectAlternativeName
-import java.math.BigInteger
-import java.net.InetAddress
-import java.net.ProtocolException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 import okio.Buffer
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
@@ -35,13 +29,19 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
+import java.math.BigInteger
+import java.net.InetAddress
+import java.net.ProtocolException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 internal class DerTest {
   @Test fun `decode tag and length`() {
     val buffer = Buffer()
-        .writeByte(0b00011110)
-        .writeByte(0b10000001)
-        .writeByte(0b11001001)
+      .writeByte(0b00011110)
+      .writeByte(0b10000001)
+      .writeByte(0b11001001)
 
     val derReader = DerReader(buffer)
 
@@ -57,10 +57,10 @@ internal class DerTest {
 
   @Test fun `decode length encoded with leading zero byte`() {
     val buffer = Buffer()
-        .writeByte(0b00000010)
-        .writeByte(0b10000010)
-        .writeByte(0b00000000)
-        .writeByte(0b01111111)
+      .writeByte(0b00000010)
+      .writeByte(0b10000010)
+      .writeByte(0b00000000)
+      .writeByte(0b01111111)
 
     val derReader = DerReader(buffer)
 
@@ -74,9 +74,9 @@ internal class DerTest {
 
   @Test fun `decode length not encoded in shortest form possible`() {
     val buffer = Buffer()
-        .writeByte(0b00000010)
-        .writeByte(0b10000001)
-        .writeByte(0b01111111)
+      .writeByte(0b00000010)
+      .writeByte(0b10000001)
+      .writeByte(0b01111111)
 
     val derReader = DerReader(buffer)
 
@@ -90,16 +90,16 @@ internal class DerTest {
 
   @Test fun `decode length equal to Long MAX_VALUE`() {
     val buffer = Buffer()
-        .writeByte(0b00000010)
-        .writeByte(0b10001000)
-        .writeByte(0b01111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
+      .writeByte(0b00000010)
+      .writeByte(0b10001000)
+      .writeByte(0b01111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
 
     val derReader = DerReader(buffer)
 
@@ -109,16 +109,16 @@ internal class DerTest {
 
   @Test fun `decode length overflowing Long`() {
     val buffer = Buffer()
-        .writeByte(0b00000010)
-        .writeByte(0b10001000)
-        .writeByte(0b10000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
-        .writeByte(0b00000000)
+      .writeByte(0b00000010)
+      .writeByte(0b10001000)
+      .writeByte(0b10000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
+      .writeByte(0b00000000)
 
     val derReader = DerReader(buffer)
 
@@ -132,18 +132,18 @@ internal class DerTest {
 
   @Test fun `decode length encoded with more than 8 bytes`() {
     val buffer = Buffer()
-        .writeByte(0b00000010)
-        .writeByte(0b10001001)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
-        .writeByte(0b11111111)
+      .writeByte(0b00000010)
+      .writeByte(0b10001001)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
+      .writeByte(0b11111111)
 
     val derReader = DerReader(buffer)
 
@@ -152,7 +152,7 @@ internal class DerTest {
       fail()
     } catch (expected: ProtocolException) {
       assertThat(expected.message)
-          .isEqualTo("length encoded with more than 8 bytes is not supported")
+        .isEqualTo("length encoded with more than 8 bytes is not supported")
     }
   }
 
@@ -170,7 +170,7 @@ internal class DerTest {
 
   @Test fun `decode primitive bit string`() {
     val buffer = Buffer()
-        .write("0307040A3B5F291CD0".decodeHex())
+      .write("0307040A3B5F291CD0".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -195,7 +195,7 @@ internal class DerTest {
 
   @Test fun `decode primitive string`() {
     val buffer = Buffer()
-        .write("1A054A6F6E6573".decodeHex())
+      .write("1A054A6F6E6573".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -224,7 +224,7 @@ internal class DerTest {
     // Type1 ::= VisibleString
     // Type2 ::= [APPLICATION 3] IMPLICIT Type1
     val buffer = Buffer()
-        .write("43054A6F6E6573".decodeHex())
+      .write("43054A6F6E6573".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -255,7 +255,7 @@ internal class DerTest {
     // Type2 ::= [APPLICATION 3] IMPLICIT Type1
     // Type3 ::= [2] Type2
     val buffer = Buffer()
-        .write("A20743054A6F6E6573".decodeHex())
+      .write("A20743054A6F6E6573".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -299,7 +299,7 @@ internal class DerTest {
     // Type3 ::= [2] Type2
     // Type4 ::= [APPLICATION 7] IMPLICIT Type3
     val buffer = Buffer()
-        .write("670743054A6F6E6573".decodeHex())
+      .write("670743054A6F6E6573".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -343,7 +343,7 @@ internal class DerTest {
     // Type2 ::= [APPLICATION 3] IMPLICIT Type1
     // Type5 ::= [2] IMPLICIT Type2
     val buffer = Buffer()
-        .write("82054A6F6E6573".decodeHex())
+      .write("82054A6F6E6573".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -365,9 +365,9 @@ internal class DerTest {
     val derWriter = DerWriter(buffer)
 
     derWriter.write(
-        name = "test",
-        tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
-        tag = 2L
+      name = "test",
+      tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
+      tag = 2L
     ) {
       derWriter.writeOctetString("Jones".encodeUtf8())
     }
@@ -377,7 +377,7 @@ internal class DerTest {
 
   @Test fun `decode object identifier without adapter`() {
     val buffer = Buffer()
-        .write("0603883703".decodeHex())
+      .write("0603883703".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -396,9 +396,9 @@ internal class DerTest {
     val derWriter = DerWriter(buffer)
 
     derWriter.write(
-        name = "test",
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 6L
+      name = "test",
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 6L
     ) {
       derWriter.writeObjectIdentifier("2.999.3")
     }
@@ -408,7 +408,7 @@ internal class DerTest {
 
   @Test fun `decode relative object identifier`() {
     val buffer = Buffer()
-        .write("0D04c27B0302".decodeHex())
+      .write("0D04c27B0302".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -427,9 +427,9 @@ internal class DerTest {
     val derWriter = DerWriter(buffer)
 
     derWriter.write(
-        name = "test",
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 13L
+      name = "test",
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 13L
     ) {
       derWriter.writeRelativeObjectIdentifier("8571.3.2")
     }
@@ -439,12 +439,12 @@ internal class DerTest {
 
   @Test fun `decode raw sequence`() {
     val buffer = Buffer()
-        .write("300A".decodeHex())
-        .write("1505".decodeHex())
-        .write("Smith".encodeUtf8())
-        .write("01".decodeHex())
-        .write("01".decodeHex())
-        .write("FF".decodeHex())
+      .write("300A".decodeHex())
+      .write("1505".decodeHex())
+      .write("Smith".encodeUtf8())
+      .write("01".decodeHex())
+      .write("01".decodeHex())
+      .write("FF".decodeHex())
 
     val derReader = DerReader(buffer)
 
@@ -472,23 +472,23 @@ internal class DerTest {
     val derWriter = DerWriter(buffer)
 
     derWriter.write(
-        name = "test",
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 16L
+      name = "test",
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 16L
     ) {
 
       derWriter.write(
-          name = "test",
-          tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-          tag = 21L
+        name = "test",
+        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+        tag = 21L
       ) {
         derWriter.writeOctetString("Smith".encodeUtf8())
       }
 
       derWriter.write(
-          name = "test",
-          tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-          tag = 1L
+        name = "test",
+        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+        tag = 1L
       ) {
         derWriter.writeBoolean(true)
       }
@@ -682,62 +682,62 @@ internal class DerTest {
 
   @Test fun `parse utc time`() {
     assertThat(Adapters.parseUtcTime("920521000000Z"))
-        .isEqualTo(date("1992-05-21T00:00:00.000+0000").time)
+      .isEqualTo(date("1992-05-21T00:00:00.000+0000").time)
     assertThat(Adapters.parseUtcTime("920622123421Z"))
-        .isEqualTo(date("1992-06-22T12:34:21.000+0000").time)
+      .isEqualTo(date("1992-06-22T12:34:21.000+0000").time)
     assertThat(Adapters.parseUtcTime("920722132100Z"))
-        .isEqualTo(date("1992-07-22T13:21:00.000+0000").time)
+      .isEqualTo(date("1992-07-22T13:21:00.000+0000").time)
   }
 
   @Test fun `decode utc time two digit year cutoff is 1950`() {
     assertThat(Adapters.parseUtcTime("500101000000Z"))
-        .isEqualTo(date("1950-01-01T00:00:00.000+0000").time)
+      .isEqualTo(date("1950-01-01T00:00:00.000+0000").time)
     assertThat(Adapters.parseUtcTime("500101010000Z"))
-        .isEqualTo(date("1950-01-01T01:00:00.000+0000").time)
+      .isEqualTo(date("1950-01-01T01:00:00.000+0000").time)
 
     assertThat(Adapters.parseUtcTime("491231225959Z"))
-        .isEqualTo(date("2049-12-31T22:59:59.000+0000").time)
+      .isEqualTo(date("2049-12-31T22:59:59.000+0000").time)
     assertThat(Adapters.parseUtcTime("491231235959Z"))
-        .isEqualTo(date("2049-12-31T23:59:59.000+0000").time)
+      .isEqualTo(date("2049-12-31T23:59:59.000+0000").time)
   }
 
   @Test fun `encode utc time two digit year cutoff is 1950`() {
     assertThat(Adapters.formatUtcTime(date("1950-01-01T00:00:00.000+0000").time))
-        .isEqualTo("500101000000Z")
+      .isEqualTo("500101000000Z")
     assertThat(Adapters.formatUtcTime(date("2049-12-31T23:59:59.000+0000").time))
-        .isEqualTo("491231235959Z")
+      .isEqualTo("491231235959Z")
   }
 
   @Test fun `parse generalized time`() {
     assertThat(Adapters.parseGeneralizedTime("18990101000000Z"))
-        .isEqualTo(date("1899-01-01T00:00:00.000+0000").time)
+      .isEqualTo(date("1899-01-01T00:00:00.000+0000").time)
     assertThat(Adapters.parseGeneralizedTime("19500101000000Z"))
-        .isEqualTo(date("1950-01-01T00:00:00.000+0000").time)
+      .isEqualTo(date("1950-01-01T00:00:00.000+0000").time)
     assertThat(Adapters.parseGeneralizedTime("20500101000000Z"))
-        .isEqualTo(date("2050-01-01T00:00:00.000+0000").time)
+      .isEqualTo(date("2050-01-01T00:00:00.000+0000").time)
     assertThat(Adapters.parseGeneralizedTime("20990101000000Z"))
-        .isEqualTo(date("2099-01-01T00:00:00.000+0000").time)
+      .isEqualTo(date("2099-01-01T00:00:00.000+0000").time)
     assertThat(Adapters.parseGeneralizedTime("19920521000000Z"))
-        .isEqualTo(date("1992-05-21T00:00:00.000+0000").time)
+      .isEqualTo(date("1992-05-21T00:00:00.000+0000").time)
     assertThat(Adapters.parseGeneralizedTime("19920622123421Z"))
-        .isEqualTo(date("1992-06-22T12:34:21.000+0000").time)
+      .isEqualTo(date("1992-06-22T12:34:21.000+0000").time)
   }
 
   @Ignore("fractional seconds are not implemented")
   @Test fun `parse generalized time with fractional seconds`() {
     assertThat(Adapters.parseGeneralizedTime("19920722132100.3Z"))
-        .isEqualTo(date("1992-07-22T13:21:00.300+0000").time)
+      .isEqualTo(date("1992-07-22T13:21:00.300+0000").time)
   }
 
   @Test fun `format generalized time`() {
     assertThat(Adapters.formatGeneralizedTime(date("1899-01-01T00:00:00.000+0000").time))
-        .isEqualTo("18990101000000Z")
+      .isEqualTo("18990101000000Z")
     assertThat(Adapters.formatGeneralizedTime(date("1950-01-01T00:00:00.000+0000").time))
-        .isEqualTo("19500101000000Z")
+      .isEqualTo("19500101000000Z")
     assertThat(Adapters.formatGeneralizedTime(date("2050-01-01T00:00:00.000+0000").time))
-        .isEqualTo("20500101000000Z")
+      .isEqualTo("20500101000000Z")
     assertThat(Adapters.formatGeneralizedTime(date("2099-01-01T00:00:00.000+0000").time))
-        .isEqualTo("20990101000000Z")
+      .isEqualTo("20990101000000Z")
   }
 
   @Test fun `decode object identifier`() {
@@ -755,13 +755,13 @@ internal class DerTest {
   @Test fun `sequence algorithm`() {
     val bytes = "300d06092a864886f70d01010b0500".decodeHex()
     val algorithmIdentifier = AlgorithmIdentifier(
-        algorithm = sha256WithRSAEncryption,
-        parameters = null
+      algorithm = sha256WithRSAEncryption,
+      parameters = null
     )
     assertThat(CertificateAdapters.algorithmIdentifier.fromDer(bytes))
-        .isEqualTo(algorithmIdentifier)
+      .isEqualTo(algorithmIdentifier)
     assertThat(CertificateAdapters.algorithmIdentifier.toDer(algorithmIdentifier))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
   }
 
   @Test fun `bit string`() {
@@ -792,7 +792,8 @@ internal class DerTest {
   @Test fun `cannot decode constructed octet string`() {
     try {
       Adapters.OCTET_STRING.fromDer(
-          "2410040668656c6c6f200406776f726c6421".decodeHex())
+        "2410040668656c6c6f200406776f726c6421".decodeHex()
+      )
       fail()
     } catch (expected: ProtocolException) {
       assertThat(expected).hasMessage("constructed octet strings not supported for DER")
@@ -802,7 +803,8 @@ internal class DerTest {
   @Test fun `cannot decode constructed bit string`() {
     try {
       Adapters.BIT_STRING.fromDer(
-          "231203070068656c6c6f20030700776f726c6421".decodeHex())
+        "231203070068656c6c6f20030700776f726c6421".decodeHex()
+      )
       fail()
     } catch (expected: ProtocolException) {
       assertThat(expected).hasMessage("constructed bit strings not supported for DER")
@@ -812,7 +814,8 @@ internal class DerTest {
   @Test fun `cannot decode constructed string`() {
     try {
       Adapters.UTF8_STRING.fromDer(
-          "2c100c0668656c6c6f200c06776f726c6421".decodeHex())
+        "2c100c0668656c6c6f200c06776f726c6421".decodeHex()
+      )
       fail()
     } catch (expected: ProtocolException) {
       assertThat(expected).hasMessage("constructed strings not supported for DER")
@@ -822,7 +825,8 @@ internal class DerTest {
   @Test fun `cannot decode indefinite length bit string`() {
     try {
       Adapters.BIT_STRING.fromDer(
-          "23800303000A3B0305045F291CD00000".decodeHex())
+        "23800303000A3B0305045F291CD00000".decodeHex()
+      )
       fail()
     } catch (expected: ProtocolException) {
       assertThat(expected).hasMessage("indefinite length not permitted for DER")
@@ -831,7 +835,7 @@ internal class DerTest {
 
   @Test fun `cannot decode constructed octet string in enclosing sequence`() {
     val buffer = Buffer()
-        .write("3A0904034A6F6E04026573".decodeHex())
+      .write("3A0904034A6F6E04026573".decodeHex())
     val derReader = DerReader(buffer)
     try {
       derReader.read("test") {
@@ -847,62 +851,62 @@ internal class DerTest {
     val bytes = "8704c0a80201".decodeHex()
     val localhost = InetAddress.getByName("192.168.2.1").address.toByteString()
     assertThat(CertificateAdapters.generalName.fromDer(bytes))
-        .isEqualTo(generalNameIpAddress to localhost)
+      .isEqualTo(generalNameIpAddress to localhost)
     assertThat(CertificateAdapters.generalName.toDer(generalNameIpAddress to localhost))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
   }
 
   @Test fun `choice dns`() {
     val bytes = "820b6578616d706c652e636f6d".decodeHex()
     assertThat(CertificateAdapters.generalName.fromDer(bytes))
-        .isEqualTo(generalNameDnsName to "example.com")
+      .isEqualTo(generalNameDnsName to "example.com")
     assertThat(CertificateAdapters.generalName.toDer(generalNameDnsName to "example.com"))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
   }
 
   @Test fun `extension with type hint for basic constraints`() {
     val extension = Extension(
-        basicConstraints,
-        false,
-        BasicConstraints(true, 4)
+      basicConstraints,
+      false,
+      BasicConstraints(true, 4)
     )
     val bytes = "300f0603551d13040830060101ff020104".decodeHex()
 
     assertThat(CertificateAdapters.extension.toDer(extension))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
     assertThat(CertificateAdapters.extension.fromDer(bytes))
-        .isEqualTo(extension)
+      .isEqualTo(extension)
   }
 
   @Test fun `extension with type hint for subject alternative names`() {
     val extension = Extension(
-        subjectAlternativeName,
-        false,
-        listOf(
-            generalNameDnsName to "cash.app",
-            generalNameDnsName to "www.cash.app"
-        )
+      subjectAlternativeName,
+      false,
+      listOf(
+        generalNameDnsName to "cash.app",
+        generalNameDnsName to "www.cash.app"
+      )
     )
     val bytes = "30210603551d11041a30188208636173682e617070820c7777772e636173682e617070".decodeHex()
 
     assertThat(CertificateAdapters.extension.toDer(extension))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
     assertThat(CertificateAdapters.extension.fromDer(bytes))
-        .isEqualTo(extension)
+      .isEqualTo(extension)
   }
 
   @Test fun `extension with unknown type hint`() {
     val extension = Extension(
-        commonName, // common name is not an extension.
-        false,
-        "3006800109810109".decodeHex()
+      commonName, // common name is not an extension.
+      false,
+      "3006800109810109".decodeHex()
     )
     val bytes = "300f060355040304083006800109810109".decodeHex()
 
     assertThat(CertificateAdapters.extension.toDer(extension))
-        .isEqualTo(bytes)
+      .isEqualTo(bytes)
     assertThat(CertificateAdapters.extension.fromDer(bytes))
-        .isEqualTo(extension)
+      .isEqualTo(extension)
   }
 
   /** Tags larger than 30 are a special case. */
@@ -950,13 +954,13 @@ internal class DerTest {
   ) {
     companion object {
       val ADAPTER = Adapters.sequence(
-          "Point",
-          Adapters.INTEGER_AS_LONG.withTag(tag = 0L)
-              .optional(),
-          Adapters.INTEGER_AS_LONG.withTag(tag = 1L)
-              .optional(),
-          decompose = { listOf(it.x, it.y) },
-          construct = { Point(it[0] as Long?, it[1] as Long?) }
+        "Point",
+        Adapters.INTEGER_AS_LONG.withTag(tag = 0L)
+          .optional(),
+        Adapters.INTEGER_AS_LONG.withTag(tag = 1L)
+          .optional(),
+        decompose = { listOf(it.x, it.y) },
+        construct = { Point(it[0] as Long?, it[1] as Long?) }
       )
     }
   }

--- a/certifikit/src/test/kotlin/app/cash/certifikit/HeldCertificate.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/HeldCertificate.kt
@@ -22,6 +22,9 @@ import app.cash.certifikit.ObjectIdentifiers.organizationalUnitName
 import app.cash.certifikit.ObjectIdentifiers.sha256WithRSAEncryption
 import app.cash.certifikit.ObjectIdentifiers.sha256withEcdsa
 import app.cash.certifikit.ObjectIdentifiers.subjectAlternativeName
+import okio.ByteString
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.toByteString
 import java.math.BigInteger
 import java.net.InetAddress
 import java.security.GeneralSecurityException
@@ -39,9 +42,6 @@ import java.security.interfaces.RSAPublicKey
 import java.security.spec.PKCS8EncodedKeySpec
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import okio.ByteString
-import okio.ByteString.Companion.decodeBase64
-import okio.ByteString.Companion.toByteString
 
 /**
  * A certificate and its private key. These are some properties of certificates that are used with
@@ -301,7 +301,7 @@ class HeldCertificate(
       // Subject keys & identity.
       val subjectKeyPair = keyPair ?: generateKeyPair()
       val subjectPublicKeyInfo = CertificateAdapters.subjectPublicKeyInfo.fromDer(
-          subjectKeyPair.public.encoded.toByteString()
+        subjectKeyPair.public.encoded.toByteString()
       )
       val subject: List<List<AttributeTypeAndValue>> = subject()
 
@@ -311,7 +311,7 @@ class HeldCertificate(
       if (signedBy != null) {
         issuerKeyPair = signedBy!!.keyPair
         issuer = CertificateAdapters.rdnSequence.fromDer(
-            signedBy!!.certificate.subjectX500Principal.encoded.toByteString()
+          signedBy!!.certificate.subjectX500Principal.encoded.toByteString()
         )
       } else {
         issuerKeyPair = subjectKeyPair
@@ -321,34 +321,35 @@ class HeldCertificate(
 
       // Subset of certificate data that's covered by the signature.
       val tbsCertificate = TbsCertificate(
-          version = 2L, // v3.
-          serialNumber = serialNumber ?: BigInteger.ONE,
-          signature = signatureAlgorithm,
-          issuer = issuer,
-          validity = validity(),
-          subject = subject,
-          subjectPublicKeyInfo = subjectPublicKeyInfo,
-          issuerUniqueID = null,
-          subjectUniqueID = null,
-          extensions = extensions()
+        version = 2L, // v3.
+        serialNumber = serialNumber ?: BigInteger.ONE,
+        signature = signatureAlgorithm,
+        issuer = issuer,
+        validity = validity(),
+        subject = subject,
+        subjectPublicKeyInfo = subjectPublicKeyInfo,
+        issuerUniqueID = null,
+        subjectUniqueID = null,
+        extensions = extensions()
       )
 
       // Signature.
       val signature = Signature.getInstance(tbsCertificate.signatureAlgorithmName).run {
         initSign(issuerKeyPair.private)
         update(
-            CertificateAdapters.tbsCertificate.toDer(tbsCertificate).toByteArray())
+          CertificateAdapters.tbsCertificate.toDer(tbsCertificate).toByteArray()
+        )
         sign().toByteString()
       }
 
       // Complete signed certificate.
       val certificate = Certificate(
-          tbsCertificate = tbsCertificate,
-          signatureAlgorithm = signatureAlgorithm,
-          signatureValue = BitString(
-              byteString = signature,
-              unusedBitsCount = 0
-          )
+        tbsCertificate = tbsCertificate,
+        signatureAlgorithm = signatureAlgorithm,
+        signatureValue = BitString(
+          byteString = signature,
+          unusedBitsCount = 0
+        )
       )
 
       return HeldCertificate(subjectKeyPair, certificate.toX509Certificate())
@@ -359,18 +360,18 @@ class HeldCertificate(
 
       if (organizationalUnit != null) {
         result += listOf(
-            AttributeTypeAndValue(
+          AttributeTypeAndValue(
             type = organizationalUnitName,
             value = organizationalUnit
-        )
+          )
         )
       }
 
       result += listOf(
-          AttributeTypeAndValue(
+        AttributeTypeAndValue(
           type = ObjectIdentifiers.commonName,
           value = commonName ?: UUID.randomUUID().toString()
-      )
+        )
       )
 
       return result
@@ -380,8 +381,8 @@ class HeldCertificate(
       val notBefore = if (notBefore != -1L) notBefore else System.currentTimeMillis()
       val notAfter = if (notAfter != -1L) notAfter else notBefore + DEFAULT_DURATION_MILLIS
       return Validity(
-          notBefore = notBefore,
-          notAfter = notAfter
+        notBefore = notBefore,
+        notAfter = notAfter
       )
     }
 
@@ -390,12 +391,12 @@ class HeldCertificate(
 
       if (maxIntermediateCas != -1) {
         result += Extension(
-            id = basicConstraints,
-            critical = true,
-            value = BasicConstraints(
-                ca = true,
-                maxIntermediateCas = maxIntermediateCas.toLong()
-            )
+          id = basicConstraints,
+          critical = true,
+          value = BasicConstraints(
+            ca = true,
+            maxIntermediateCas = maxIntermediateCas.toLong()
+          )
         )
       }
 
@@ -411,9 +412,9 @@ class HeldCertificate(
           }
         }
         result += Extension(
-            id = subjectAlternativeName,
-            critical = true,
-            value = extensionValue
+          id = subjectAlternativeName,
+          critical = true,
+          value = extensionValue
         )
       }
 
@@ -423,12 +424,12 @@ class HeldCertificate(
     private fun signatureAlgorithm(signedByKeyPair: KeyPair): AlgorithmIdentifier {
       return when (signedByKeyPair.private) {
         is RSAPrivateKey -> AlgorithmIdentifier(
-            algorithm = sha256WithRSAEncryption,
-            parameters = null
+          algorithm = sha256WithRSAEncryption,
+          parameters = null
         )
         else -> AlgorithmIdentifier(
-            algorithm = sha256withEcdsa,
-            parameters = ByteString.EMPTY
+          algorithm = sha256withEcdsa,
+          parameters = ByteString.EMPTY
         )
       }
     }
@@ -512,7 +513,7 @@ class HeldCertificate(
       val certificate = certificatePem.decodeCertificatePem()
 
       val pkcs8Bytes = pkcs8Base64Text.decodeBase64()
-          ?: throw IllegalArgumentException("failed to decode private key")
+        ?: throw IllegalArgumentException("failed to decode private key")
 
       // The private key doesn't tell us its type but it's okay because the certificate knows!
       val keyType = when (certificate.publicKey) {

--- a/certifikit/src/test/kotlin/app/cash/certifikit/KeyUsageTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/KeyUsageTest.kt
@@ -26,17 +26,24 @@ class KeyUsageTest {
   @Test
   fun testKnownValues() {
     assertThat(BitString("80".decodeHex(), unusedBitsCount = 7).decodeKeyUsage()).containsExactly(
-        DigitalSignature)
+      DigitalSignature
+    )
     assertThat(BitString("06".decodeHex(), unusedBitsCount = 1).decodeKeyUsage()).containsExactly(
-        KeyCertSign, CRLSign)
+      KeyCertSign,
+      CRLSign
+    )
     assertThat(BitString("86".decodeHex(), unusedBitsCount = 1).decodeKeyUsage()).containsExactly(
-        DigitalSignature, KeyCertSign, CRLSign)
+      DigitalSignature,
+      KeyCertSign,
+      CRLSign
+    )
   }
 
   @Test
   fun testEdgeValues() {
     assertThat(BitString("".decodeHex(), unusedBitsCount = 0).decodeKeyUsage()).isEmpty()
     assertThat(BitString("FF80".decodeHex(), unusedBitsCount = 7).decodeKeyUsage()).containsExactly(
-        *KeyUsage.values())
+      *KeyUsage.values()
+    )
   }
 }

--- a/certifikit/src/test/kotlin/app/cash/certifikit/attestation/AttestationTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/attestation/AttestationTest.kt
@@ -33,7 +33,8 @@ class AttestTest {
   @Test
   fun `decode attestation certificate`() {
     // https://github.com/google/android-key-attestation/blob/master/server/examples/pem/algorithm_EC_SecurityLevel_StrongBox/cert0.pem
-    val certificateBase64 = """
+    val certificateBase64 =
+      """
         |MIID8zCCA5egAwIBAgIBATAMBggqhkjOPQQDAgUAMC8xGTAXBgNVBAUTEDY5N2JjNjRiNmNkNGMw
         |MWUxEjAQBgNVBAwMCVN0cm9uZ0JveDAeFw03MDAxMDEwMDAwMDBaFw0yODA1MjMyMzU5NTlaMB8x
         |HTAbBgNVBAMMFEFuZHJvaWQgS2V5c3RvcmUgS2V5MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
@@ -54,7 +55,8 @@ class AttestTest {
         |VvW2Fj/ZKOkcy8p/AiAFhziu1TGVBklOdPH4usrPM/FxAvlOSUDQwj4HP/9PSg==
         |""".trimMargin()
     val certificateByteString = certificateBase64.decodeBase64()!!
-    val certificatePem = """
+    val certificatePem =
+      """
         |-----BEGIN CERTIFICATE-----
         |$certificateBase64
         |-----END CERTIFICATE-----
@@ -62,45 +64,45 @@ class AttestTest {
 
     val javaCertificate = certificatePem.decodeCertificatePem()
     val okHttpCertificate = CertificateAdapters.certificate
-        .fromDer(certificateByteString)
+      .fromDer(certificateByteString)
 
     assertThat(okHttpCertificate.signatureValue.byteString)
-        .isEqualTo(javaCertificate.signature.toByteString())
+      .isEqualTo(javaCertificate.signature.toByteString())
 
     val keyDescription = okHttpCertificate.tbsCertificate.extensions.first {
       it.id == AttestationAdapters.KEY_DESCRIPTION_OID
     }.value as KeyDescription
 
     assertThat(keyDescription).isEqualTo(
-        KeyDescription(
-            attestationVersion = 3L,
-            attestationSecurityLevel = 2L, // 2=StrongBox
-            keymasterVersion = 4L,
-            keymasterSecurityLevel = 2L, // 2=StrongBox
-            attestationChallenge = "abc".encodeUtf8(),
-            uniqueId = ByteString.EMPTY,
-            softwareEnforced = AuthorizationList(
-                creationDateTime = 1562602372883L,
-                attestationApplicationId = "308201b33182018b300c0407616e64726f696402011d30190414636f6d2e616e64726f69642e6b6579636861696e02011d30190414636f6d2e616e64726f69642e73657474696e677302011d30190414636f6d2e7174692e64696167736572766963657302011d301a0415636f6d2e616e64726f69642e64796e73797374656d02011d301d0418636f6d2e616e64726f69642e696e7075746465766963657302011d301f041a636f6d2e616e64726f69642e6c6f63616c7472616e73706f727402011d301f041a636f6d2e616e64726f69642e6c6f636174696f6e2e667573656402011d301f041a636f6d2e616e64726f69642e7365727665722e74656c65636f6d02011d3020041b636f6d2e616e64726f69642e77616c6c70617065726261636b757002011d3021041c636f6d2e676f6f676c652e5353526573746172744465746563746f7202011d3022041d636f6d2e676f6f676c652e616e64726f69642e68696464656e6d656e750201013023041e636f6d2e616e64726f69642e70726f7669646572732e73657474696e677302011d31220420301aa3cb081134501c45f1422abc66c24224fd5ded5fdc8f17e697176fd866aa".decodeHex()
-            ),
-            teeEnforced = AuthorizationList(
-                purpose = listOf(2L, 3L),
-                algorithm = 3L,
-                keySize = 256L,
-                digest = listOf(4L),
-                origin = 0,
-                rootOfTrust = RootOfTrust(
-                    verifiedBootKey = "0000000000000000000000000000000000000000000000000000000000000000".decodeHex(),
-                    deviceLocked = false,
-                    verifiedBootState = 2L,
-                    verifiedBootHash = "728db1274f1f1cf1571de4380b048a554ac4a380e76f5355083529084a937801".decodeHex()
-                ),
-                osVersion = 0L,
-                osPatchLevel = 201907L,
-                vendorPatchLevel = 20190705L,
-                bootPatchLevel = 20190700L
-            )
+      KeyDescription(
+        attestationVersion = 3L,
+        attestationSecurityLevel = 2L, // 2=StrongBox
+        keymasterVersion = 4L,
+        keymasterSecurityLevel = 2L, // 2=StrongBox
+        attestationChallenge = "abc".encodeUtf8(),
+        uniqueId = ByteString.EMPTY,
+        softwareEnforced = AuthorizationList(
+          creationDateTime = 1562602372883L,
+          attestationApplicationId = "308201b33182018b300c0407616e64726f696402011d30190414636f6d2e616e64726f69642e6b6579636861696e02011d30190414636f6d2e616e64726f69642e73657474696e677302011d30190414636f6d2e7174692e64696167736572766963657302011d301a0415636f6d2e616e64726f69642e64796e73797374656d02011d301d0418636f6d2e616e64726f69642e696e7075746465766963657302011d301f041a636f6d2e616e64726f69642e6c6f63616c7472616e73706f727402011d301f041a636f6d2e616e64726f69642e6c6f636174696f6e2e667573656402011d301f041a636f6d2e616e64726f69642e7365727665722e74656c65636f6d02011d3020041b636f6d2e616e64726f69642e77616c6c70617065726261636b757002011d3021041c636f6d2e676f6f676c652e5353526573746172744465746563746f7202011d3022041d636f6d2e676f6f676c652e616e64726f69642e68696464656e6d656e750201013023041e636f6d2e616e64726f69642e70726f7669646572732e73657474696e677302011d31220420301aa3cb081134501c45f1422abc66c24224fd5ded5fdc8f17e697176fd866aa".decodeHex()
+        ),
+        teeEnforced = AuthorizationList(
+          purpose = listOf(2L, 3L),
+          algorithm = 3L,
+          keySize = 256L,
+          digest = listOf(4L),
+          origin = 0,
+          rootOfTrust = RootOfTrust(
+            verifiedBootKey = "0000000000000000000000000000000000000000000000000000000000000000".decodeHex(),
+            deviceLocked = false,
+            verifiedBootState = 2L,
+            verifiedBootHash = "728db1274f1f1cf1571de4380b048a554ac4a380e76f5355083529084a937801".decodeHex()
+          ),
+          osVersion = 0L,
+          osPatchLevel = 201907L,
+          vendorPatchLevel = 20190705L,
+          bootPatchLevel = 20190700L
         )
+      )
     )
   }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext.dep = [
   "kotlinGradlePlugin": "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0",
   "kotlinReflection": "org.jetbrains.kotlin:kotlin-reflect:1.4.0",
   "kotlinStdLib": "org.jetbrains.kotlin:kotlin-stdlib:1.4.0",
-  "ktlintVersion": "0.34.2",
+  "ktlintVersion": "0.38.0",
   "mavenPublishGradlePlugin": "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
   "okio": "com.squareup.okio:okio:2.7.0",
   "spotlessPlugin": "com.diffplug.spotless:spotless-plugin-gradle:5.1.2",


### PR DESCRIPTION
Not for immediate landing.  So assuming we upgrade ktlint and want spotlessApply to ideally agree with Intellij kotlin formatting, there is some work to do.

With .editorconfig below, there is minimal diffs/reverts

```
[*.kt]
indent_size = 2
```

But without the above the changes between intellij formatting and spotless are large.

What is your current workflow?