### PR TITLE
Support for legacy encodings

### DIFF
--- a/certifikit/src/main/kotlin/app/cash/certifikit/Adapters.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/Adapters.kt
@@ -99,6 +99,8 @@ internal object Adapters {
       }
   )
 
+  // For a complete list of String types see https://www.obj-sys.com/asn1tutorial/node128.html examples.
+
   val UTF8_STRING = BasicDerAdapter(
       name = "UTF8",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
@@ -121,6 +123,18 @@ internal object Adapters {
       name = "PRINTABLE STRING",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
       tag = 19L,
+      codec = object : BasicDerAdapter.Codec<String> {
+        override fun decode(reader: DerReader) = reader.readUtf8String()
+        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+      }
+  )
+
+  // http://cr.openjdk.java.net/~asmotrak/8028431/webrev.02/src/share/classes/sun/security/util/DerValue.java.html
+  // TODO(yschimke): constrain to teletex subset of ISO-8859-1.
+  val TELETEX = BasicDerAdapter(
+      name = "TELETEX",
+      tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+      tag = 20L,
       codec = object : BasicDerAdapter.Codec<String> {
         override fun decode(reader: DerReader) = reader.readUtf8String()
         override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)

--- a/certifikit/src/main/kotlin/app/cash/certifikit/CertificateAdapters.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/CertificateAdapters.kt
@@ -273,6 +273,7 @@ object CertificateAdapters {
       Adapters.any(
           String::class to Adapters.UTF8_STRING,
           Nothing::class to Adapters.PRINTABLE_STRING,
+          Void::class to Adapters.TELETEX,
           AnyValue::class to Adapters.ANY_VALUE
       ),
       decompose = {

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -45,7 +45,10 @@ data class Certificate(
       return tbsCertificate.subject
           .flatten()
           .firstOrNull { it.type == ObjectIdentifiers.commonName }
-          ?.value as String?
+          ?.value?.let {
+            // This allows for legacy encodings like Teletex but left fugly.
+            it as? String ?: it.toString()
+          }
     }
 
   val organizationalUnitName: String?

--- a/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
+++ b/certifikit/src/main/kotlin/app/cash/certifikit/certificates.kt
@@ -45,10 +45,7 @@ data class Certificate(
       return tbsCertificate.subject
           .flatten()
           .firstOrNull { it.type == ObjectIdentifiers.commonName }
-          ?.value?.let {
-            // This allows for legacy encodings like Teletex but left fugly.
-            it as? String ?: it.toString()
-          }
+          ?.value?.toString() // This allows for legacy encodings like Teletex but left fugly.
     }
 
   val organizationalUnitName: String?

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -57,7 +57,7 @@ internal class DerCertificatesTest {
   private val extendedKeyUsage = "2.5.29.37"
 
   fun X509Certificate.sha256Hash(): ByteString =
-    publicKey.encoded.toByteString().sha256()
+      publicKey.encoded.toByteString().sha256()
 
   @Test
   fun `decode simple certificate`() {
@@ -650,9 +650,9 @@ internal class DerCertificatesTest {
     assertThat(okHttpCertificate.commonName).isEqualTo("Jurassic Park")
     assertThat(okHttpCertificate.organizationalUnitName).isEqualTo("Gene Research")
     assertThat(okHttpCertificate.subjectAlternativeNames).isEqualTo(listOf(
-            CertificateAdapters.generalNameDnsName to "*.example.com",
-            CertificateAdapters.generalNameDnsName to "www.example.org"
-        )
+        CertificateAdapters.generalNameDnsName to "*.example.com",
+        CertificateAdapters.generalNameDnsName to "www.example.org"
+    )
     )
     assertThat(okHttpCertificate.tbsCertificate.validity).isEqualTo(Validity(-1000L, 2000L))
     assertThat(okHttpCertificate.tbsCertificate.serialNumber).isEqualTo(BigInteger("17"))
@@ -714,7 +714,8 @@ internal class DerCertificatesTest {
         .isEqualTo(BitString(publicKeyBytes, 0))
   }
 
-  @Test fun `time before 2050 uses UTC_TIME`() {
+  @Test
+  fun `time before 2050 uses UTC_TIME`() {
     val utcTimeDer = "170d3439313233313233353935395a".decodeHex()
 
     val decoded = CertificateAdapters.time.fromDer(utcTimeDer)
@@ -724,7 +725,8 @@ internal class DerCertificatesTest {
     assertThat(encoded).isEqualTo(utcTimeDer)
   }
 
-  @Test fun `time not before 2050 uses GENERALIZED_TIME`() {
+  @Test
+  fun `time not before 2050 uses GENERALIZED_TIME`() {
     val generalizedTimeDer = "180f32303530303130313030303030305a".decodeHex()
 
     val decoded = CertificateAdapters.time.fromDer(generalizedTimeDer)
@@ -738,14 +740,16 @@ internal class DerCertificatesTest {
    * Conforming applications MUST be able to process validity dates that are encoded in either
    * UTCTime or GeneralizedTime.
    */
-  @Test fun `can read GENERALIZED_TIME before 2050`() {
+  @Test
+  fun `can read GENERALIZED_TIME before 2050`() {
     val generalizedTimeDer = "180f32303439313233313233353935395a".decodeHex()
 
     val decoded = CertificateAdapters.time.fromDer(generalizedTimeDer)
     assertThat(decoded).isEqualTo(date("2049-12-31T23:59:59.000+0000").time)
   }
 
-  @Test fun `time before 1950 uses GENERALIZED_TIME`() {
+  @Test
+  fun `time before 1950 uses GENERALIZED_TIME`() {
     val generalizedTimeDer = "180f31393439313233313233353935395a".decodeHex()
 
     val decoded = CertificateAdapters.time.fromDer(generalizedTimeDer)
@@ -908,15 +912,56 @@ internal class DerCertificatesTest {
 
     val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
     assertThat(decoded.subjectAlternativeNames).isEqualTo(listOf(
-            Adapters.ANY_VALUE to AnyValue(
-                tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
-                tag = 1L,
-                constructed = false,
-                length = 16,
-                bytes = "ca@trustwave.com".encodeUtf8()
-            )
+        Adapters.ANY_VALUE to AnyValue(
+            tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
+            tag = 1L,
+            constructed = false,
+            length = 16,
+            bytes = "ca@trustwave.com".encodeUtf8()
         )
     )
+    )
+  }
+
+  /**
+   * Test for weird encoding of common name.
+   */
+  @Test
+  fun `teletex encoding`() {
+    val certificateByteString = ("MIIFSzCCBDOgAwIBAgIQSueVSfqavj8QDxekeOFpCTANBgkqhkiG9w0BAQsFADCB" +
+        "kDELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G" +
+        "A1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxNjA0BgNV" +
+        "BAMTLUNPTU9ETyBSU0EgRG9tYWluIFZhbGlkYXRpb24gU2VjdXJlIFNlcnZlciBD" +
+        "QTAeFw0xNTA0MDkwMDAwMDBaFw0xNTA0MTIyMzU5NTlaMFkxITAfBgNVBAsTGERv" +
+        "bWFpbiBDb250cm9sIFZhbGlkYXRlZDEdMBsGA1UECxMUUG9zaXRpdmVTU0wgV2ls" +
+        "ZGNhcmQxFTATBgNVBAMUDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD" +
+        "ggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2PmzA" +
+        "S2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMWhyef" +
+        "dOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3AxPxT" +
+        "uW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqveww9H" +
+        "dFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SYQCeF" +
+        "xxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaOCAdUwggHRMB8GA1Ud" +
+        "IwQYMBaAFJCvajqUWgvYkOoSVnPfQ7Q6KNrnMB0GA1UdDgQWBBSd7sF7gQs6R2lx" +
+        "GH0RN5O8pRs/+zAOBgNVHQ8BAf8EBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUE" +
+        "FjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwTwYDVR0gBEgwRjA6BgsrBgEEAbIxAQIC" +
+        "BzArMCkGCCsGAQUFBwIBFh1odHRwczovL3NlY3VyZS5jb21vZG8uY29tL0NQUzAI" +
+        "BgZngQwBAgEwVAYDVR0fBE0wSzBJoEegRYZDaHR0cDovL2NybC5jb21vZG9jYS5j" +
+        "b20vQ09NT0RPUlNBRG9tYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNybDCB" +
+        "hQYIKwYBBQUHAQEEeTB3ME8GCCsGAQUFBzAChkNodHRwOi8vY3J0LmNvbW9kb2Nh" +
+        "LmNvbS9DT01PRE9SU0FEb21haW5WYWxpZGF0aW9uU2VjdXJlU2VydmVyQ0EuY3J0" +
+        "MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5jb21vZG9jYS5jb20wIwYDVR0RBBww" +
+        "GoIMKi5iYWRzc2wuY29tggpiYWRzc2wuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBq" +
+        "evHa/wMHcnjFZqFPRkMOXxQhjHUa6zbgH6QQFezaMyV8O7UKxwE4PSf9WNnM6i1p" +
+        "OXy+l+8L1gtY54x/v7NMHfO3kICmNnwUW+wHLQI+G1tjWxWrAPofOxkt3+IjEBEH" +
+        "fnJ/4r+3ABuYLyw/zoWaJ4wQIghBK4o+gk783SHGVnRwpDTysUCeK1iiWQ8dSO/r" +
+        "ET7BSp68ZVVtxqPv1dSWzfGuJ/ekVxQ8lEEFeouhN0fX9X3c+s5vMaKwjOrMEpsi" +
+        "8TRwz311SotoKQwe6Zaoz7ASH1wq7mcvf71z81oBIgxw+s1F73hczg36TuHvzmWf" +
+        "RwxPuzZEaFZcVlmtqoq8")
+        .decodeBase64()!!
+
+    val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
+    // TODO: This seems wrong, agree before landing.
+    assertThat(decoded.commonName).isEqualTo("AnyValue(tagClass=0, tag=20, constructed=false, length=12, bytes=[text=*.badssl.com])")
   }
 
   /** Converts public key bytes to SubjectPublicKeyInfo bytes. */

--- a/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
+++ b/certifikit/src/test/kotlin/app/cash/certifikit/DerCertificatesTest.kt
@@ -960,8 +960,7 @@ internal class DerCertificatesTest {
         .decodeBase64()!!
 
     val decoded = CertificateAdapters.certificate.fromDer(certificateByteString)
-    // TODO: This seems wrong, agree before landing.
-    assertThat(decoded.commonName).isEqualTo("AnyValue(tagClass=0, tag=20, constructed=false, length=12, bytes=[text=*.badssl.com])")
+    assertThat(decoded.commonName).isEqualTo("*.badssl.com")
   }
 
   /** Converts public key bytes to SubjectPublicKeyInfo bytes. */


### PR DESCRIPTION
I am invoking the McDonald's theory https://medium.com/@jonbell/mcdonalds-theory-9216e1c9da7d, seems wrong because we expose our internal toString as factual data.

```
 ./cft --host expired.badssl.com --insecure
CN: 	AnyValue(tagClass=0, tag=20, constructed=false, length=12, bytes=[text=*.badssl.com])
Pin:	sha256/f522e496c72fccc623f1ffb9da5a79cdefe16340851f22d23d0cd2a58608066f
```

Want to discuss before implementing rest of them.