### PR TITLE
Support output to STDOUT

### DIFF
--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
@@ -18,6 +18,9 @@ package app.cash.certifikit.cli
 import app.cash.certifikit.Certificate
 import app.cash.certifikit.CertificateAdapters
 import app.cash.certifikit.cli.errors.UsageException
+import java.io.File
+import java.io.FileNotFoundException
+import java.security.cert.X509Certificate
 import okio.ByteString.Companion.decodeBase64
 
 internal fun String.parsePemCertificate(fileName: String? = null): Certificate {
@@ -29,4 +32,20 @@ internal fun String.parsePemCertificate(fileName: String? = null): Certificate {
     val data = pemBody.decodeBase64()!!
 
     return CertificateAdapters.certificate.fromDer(data)
+}
+
+internal fun File.parsePemCertificate(): Certificate {
+    try {
+        val pemText = readText()
+
+        return pemText.parsePemCertificate(name)
+    } catch (fnfe: FileNotFoundException) {
+        throw UsageException("No such file: $this", fnfe)
+    }
+}
+
+internal fun X509Certificate.writePem(
+  output: File
+) {
+    output.writeText(certificatePem())
 }

--- a/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
+++ b/certifikit-cli/src/main/kotlin/app/cash/certifikit/cli/certs.kt
@@ -24,28 +24,28 @@ import java.security.cert.X509Certificate
 import okio.ByteString.Companion.decodeBase64
 
 internal fun String.parsePemCertificate(fileName: String? = null): Certificate {
-    val regex = """-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----""".toRegex(RegexOption.DOT_MATCHES_ALL)
-    val matchResult = regex.find(this) ?: throw UsageException("Invalid format" +
-            if (fileName != null) ": $fileName" else "")
+  val regex = """-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----""".toRegex(RegexOption.DOT_MATCHES_ALL)
+  val matchResult = regex.find(this) ?: throw UsageException("Invalid format" +
+      if (fileName != null) ": $fileName" else "")
     val (pemBody) = matchResult.destructured
 
-    val data = pemBody.decodeBase64()!!
+  val data = pemBody.decodeBase64()!!
 
-    return CertificateAdapters.certificate.fromDer(data)
+  return CertificateAdapters.certificate.fromDer(data)
 }
 
 internal fun File.parsePemCertificate(): Certificate {
-    try {
-        val pemText = readText()
+  try {
+    val pemText = readText()
 
-        return pemText.parsePemCertificate(name)
-    } catch (fnfe: FileNotFoundException) {
-        throw UsageException("No such file: $this", fnfe)
-    }
+    return pemText.parsePemCertificate(name)
+  } catch (fnfe: FileNotFoundException) {
+    throw UsageException("No such file: $this", fnfe)
+  }
 }
 
 internal fun X509Certificate.writePem(
   output: File
 ) {
-    output.writeText(certificatePem())
+  output.writeText(certificatePem())
 }


### PR DESCRIPTION
Testing to grab an example certificate

```
 ./cft --host expired.badssl.com --insecure --output -
-----BEGIN CERTIFICATE-----
MIIFSzCCBDOgAwIBAgIQSueVSfqavj8QDxekeOFpCTANBgkqhkiG9w0BAQsFADCB
kDELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G
A1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxNjA0BgNV
BAMTLUNPTU9ETyBSU0EgRG9tYWluIFZhbGlkYXRpb24gU2VjdXJlIFNlcnZlciBD
QTAeFw0xNTA0MDkwMDAwMDBaFw0xNTA0MTIyMzU5NTlaMFkxITAfBgNVBAsTGERv
bWFpbiBDb250cm9sIFZhbGlkYXRlZDEdMBsGA1UECxMUUG9zaXRpdmVTU0wgV2ls
ZGNhcmQxFTATBgNVBAMUDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD
ggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2PmzA
S2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMWhyef
dOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3AxPxT
uW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqveww9H
dFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SYQCeF
xxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaOCAdUwggHRMB8GA1Ud
IwQYMBaAFJCvajqUWgvYkOoSVnPfQ7Q6KNrnMB0GA1UdDgQWBBSd7sF7gQs6R2lx
GH0RN5O8pRs/+zAOBgNVHQ8BAf8EBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUE
FjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwTwYDVR0gBEgwRjA6BgsrBgEEAbIxAQIC
BzArMCkGCCsGAQUFBwIBFh1odHRwczovL3NlY3VyZS5jb21vZG8uY29tL0NQUzAI
BgZngQwBAgEwVAYDVR0fBE0wSzBJoEegRYZDaHR0cDovL2NybC5jb21vZG9jYS5j
b20vQ09NT0RPUlNBRG9tYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNybDCB
hQYIKwYBBQUHAQEEeTB3ME8GCCsGAQUFBzAChkNodHRwOi8vY3J0LmNvbW9kb2Nh
LmNvbS9DT01PRE9SU0FEb21haW5WYWxpZGF0aW9uU2VjdXJlU2VydmVyQ0EuY3J0
MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5jb21vZG9jYS5jb20wIwYDVR0RBBww
GoIMKi5iYWRzc2wuY29tggpiYWRzc2wuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBq
evHa/wMHcnjFZqFPRkMOXxQhjHUa6zbgH6QQFezaMyV8O7UKxwE4PSf9WNnM6i1p
OXy+l+8L1gtY54x/v7NMHfO3kICmNnwUW+wHLQI+G1tjWxWrAPofOxkt3+IjEBEH
fnJ/4r+3ABuYLyw/zoWaJ4wQIghBK4o+gk783SHGVnRwpDTysUCeK1iiWQ8dSO/r
ET7BSp68ZVVtxqPv1dSWzfGuJ/ekVxQ8lEEFeouhN0fX9X3c+s5vMaKwjOrMEpsi
8TRwz311SotoKQwe6Zaoz7ASH1wq7mcvf71z81oBIgxw+s1F73hczg36TuHvzmWf
RwxPuzZEaFZcVlmtqoq8
-----END CERTIFICATE-----

CN: 	AnyValue(tagClass=0, tag=20, constructed=false, length=12, bytes=[text=*.badssl.com])
Pin:	sha256/f522e496c72fccc623f1ffb9da5a79cdefe16340851f22d23d0cd2a58608066f
SAN: 	*.badssl.com, badssl.com
OU: 	Domain Control Validated
Key Usage: DigitalSignature, KeyEncipherment
Ext Key Usage: serverAuth, clientAuth
Valid: 	2015-04-09T00:00:00Z..2015-04-12T23:59:59Z (Not valid)
CA: false
```